### PR TITLE
support more textequiv levels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 *.egg-info
 repo/assets
 test/assets
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - 2.7
   - 3.4
+  - 3.6
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install build-essential autoconf-archive libpango1.0-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ install:
   - make deps-pip deps-pip-test
 
 script:
-  - make assets test TESSDATA_PREFIX="/usr/share/tessdata" OCRD_BASEURL="https://github.com/OCR-D/ocrd-assets/raw/master/data/"
+  - make test TESSDATA_PREFIX="/usr/share/tessdata" OCRD_BASEURL="https://github.com/OCR-D/ocrd-assets/raw/master/data/"

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ PIP = pip
 LOG_LEVEL = INFO
 PYTHONIOENCODING=utf8
 
+# pytest args. Set to '-s' to see log output during test execution, '--verbose' to see individual tests. Default: '$(PYTEST_ARGS)'
+PYTEST_ARGS =
+
 # Docker container tag
 DOCKER_TAG = 'ocrd/tesserocr'
 
@@ -15,8 +18,8 @@ help:
 	@echo ""
 	@echo "  Targets"
 	@echo ""
-	@echo "    deps-ubuntu    Dependencies for deployment in an ubuntu/debian linux"
 	@echo "    patch-header   Add default parameter to regain downward compatibility"
+	@echo "    deps-ubuntu    Dependencies for deployment in an ubuntu/debian linux"
 	@echo "    deps-pip       Install python deps via pip"
 	@echo "    deps-pip-test  Install testing deps via pip"
 	@echo "    install        Install"
@@ -28,7 +31,8 @@ help:
 	@echo ""
 	@echo "  Variables"
 	@echo ""
-	@echo "    DOCKER_TAG  Docker container tag"
+	@echo "    PYTEST_ARGS  pytest args. Set to '-s' to see log output during test execution, '--verbose' to see individual tests. Default: '$(PYTEST_ARGS)'"
+	@echo "    DOCKER_TAG      Docker container tag"
 
 # END-EVAL
 
@@ -67,7 +71,8 @@ docker:
 .PHONY: test install deps deps-ubuntu deps-pip deps-pip-test help
 # Run test
 test: test/assets
-	$(PYTHON) -m pytest test
+	# declare -p HTTP_PROXY
+	$(PYTHON) -m pytest test $(PYTEST_ARGS)
 
 #
 # Assets

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ help:
 	@echo "    docker         Build docker image"
 	@echo "    test           Run test"
 	@echo "    repo/assets    Clone OCR-D/assets to ./repo/assets"
-	@echo "    assets         Setup test assets"
+	@echo "    test/assets    Setup test assets"
 	@echo "    assets-clean   Remove symlinks in test/assets"
 	@echo ""
 	@echo "  Variables"
@@ -64,9 +64,9 @@ install:
 docker:
 	docker build -t $(DOCKER_TAG) .
 
-.PHONY: test
+.PHONY: test install deps deps-ubuntu deps-pip deps-pip-test help
 # Run test
-test:
+test: test/assets
 	$(PYTHON) -m pytest test
 
 #
@@ -80,10 +80,11 @@ repo/assets:
 
 
 # Setup test assets
-assets: repo/assets
-	mkdir -p test/assets
-	cp -r -t test/assets repo/assets/data/*
+test/assets: repo/assets
+	mkdir -p $@
+	cp -r -t $@ repo/assets/data/*
 
+.PHONY: assets-clean
 # Remove symlinks in test/assets
 assets-clean:
 	rm -rf test/assets

--- a/ocrd_tesserocr/cli.py
+++ b/ocrd_tesserocr/cli.py
@@ -4,6 +4,7 @@ from ocrd.decorators import ocrd_cli_options, ocrd_cli_wrap_processor
 from ocrd_tesserocr.recognize import TesserocrRecognize
 from ocrd_tesserocr.segment_region import TesserocrSegmentRegion
 from ocrd_tesserocr.segment_line import TesserocrSegmentLine
+from ocrd_tesserocr.segment_word import TesserocrSegmentWord
 
 @click.command()
 @ocrd_cli_options
@@ -14,6 +15,11 @@ def ocrd_tesserocr_segment_region(*args, **kwargs):
 @ocrd_cli_options
 def ocrd_tesserocr_segment_line(*args, **kwargs):
     return ocrd_cli_wrap_processor(TesserocrSegmentLine, *args, **kwargs)
+
+@click.command()
+@ocrd_cli_options
+def ocrd_tesserocr_segment_word(*args, **kwargs):
+    return ocrd_cli_wrap_processor(TesserocrSegmentWord, *args, **kwargs)
 
 @click.command()
 @ocrd_cli_options

--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -12,7 +12,8 @@
         "textequiv_level": {
           "type": "string",
           "enum": ["page", "region", "line", "word", "glyph"],
-          "default": "line"
+            "default": "line",
+          "description": "PAGE XML hierarchy level at which to add the TextEquiv results (requires existing layout annotation up to one level above that)"
         },
         "model": {
           "type": "string",

--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.1",
+  "version": "0.1.0",
   "git_url": "https://github.com/OCR-D/ocrd_tesserocr",
   "dockerhub": "ocrd/tesserocr",
   "tools": {

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -268,7 +268,7 @@ class TesserocrRecognize(Processor):
                             else:
                                 result_it.Next(RIL.WORD)
                 ID = concat_padded(self.output_file_grp, n)
-                self.add_output_file(
+                self.workspace.add_file(
                     ID=ID,
                     file_grp=self.output_file_grp,
                     basename=ID + '.xml',

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -113,7 +113,7 @@ class TesserocrRecognize(Processor):
                         tessapi.SetPageSegMode(PSM.SINGLE_BLOCK)
                         if region.get_TextEquiv():
                             log.warn("Region '%s' already contains text results", region.id)
-                        region.add_TextEquiv(TextEquivType(Unicode=tessapi.GetUTF8Text()))
+                        region.add_TextEquiv(TextEquivType(Unicode=tessapi.GetUTF8Text().strip()))
                         continue # next region (to avoid indentation below)
                     ## line, word, or glyph level:
                     textlines = region.get_TextLine()
@@ -132,7 +132,7 @@ class TesserocrRecognize(Processor):
                         for (word_no, conf) in enumerate(tessapi.AllWordConfidences()): # or tessapi.MeanTextConf()?
                             line_conf *= conf/100.0
                         # add line annotation unconditionally (i.e. even for word or glyph level):
-                        line.add_TextEquiv(TextEquivType(Unicode=tessapi.GetUTF8Text(), conf=line_conf))
+                        line.add_TextEquiv(TextEquivType(Unicode=tessapi.GetUTF8Text().strip(), conf=line_conf))
                         if maxlevel == 'line':
                             # maybe add TextEquiv alternatives via ChoiceIterator for TEXTLINE?
                             continue # next line (to avoid indentation below)
@@ -150,7 +150,7 @@ class TesserocrRecognize(Processor):
                                 if word.get_TextEquiv():
                                     log.warn("Word '%s' already contains text results", word.id)
                                 word_conf = tessapi.AllWordConfidences()[0]/100.0
-                                word.add_TextEquiv(TextEquivType(Unicode=tessapi.GetUTF8Text(), conf=word_conf))
+                                word.add_TextEquiv(TextEquivType(Unicode=tessapi.GetUTF8Text().strip(), conf=word_conf))
                                 if maxlevel == 'word':
                                     # maybe add TextEquiv alternatives via ChoiceIterator for WORD?
                                     continue # next word (to avoid indentation below)
@@ -168,7 +168,7 @@ class TesserocrRecognize(Processor):
                                         if glyph.get_TextEquiv():
                                             log.warn("Glyph '%s' already contains text results", glyph.id)
                                         glyph_conf = tessapi.AllWordConfidences()[0]/100.0
-                                        glyph.add_TextEquiv(TextEquivType(Unicode=tessapi.GetUTF8Text(), conf=glyph_conf))
+                                        glyph.add_TextEquiv(TextEquivType(Unicode=tessapi.GetUTF8Text().strip(), conf=glyph_conf))
                                         # maybe add TextEquiv alternatives via ChoiceIterator for SYMBOL?
                                     continue # next word (to avoid indentation below)
                                 ## internal glyph layout:

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
 
-from tesserocr import RIL, PSM, PyTessBaseAPI, get_languages, iterate_level
-from ocrd.utils import getLogger, concat_padded, xywh_from_points, points_from_x0y0x1y1
-from ocrd.model.ocrd_page import from_file, to_xml, TextEquivType, CoordsType, GlyphType
+from tesserocr import RIL, PSM, PyTessBaseAPI, PyResultIterator, get_languages, iterate_level
+from ocrd.utils import getLogger, concat_padded, xywh_from_points, points_from_xywh, points_from_x0y0x1y1
+from ocrd.model.ocrd_page import from_file, to_xml, TextEquivType, CoordsType, GlyphType, WordType
+from ocrd.model.ocrd_page_generateds import TextStyleType
 from ocrd import Processor, MIMETYPE_PAGE
 from ocrd_tesserocr.config import TESSDATA_PREFIX, OCRD_TOOL
 
@@ -20,8 +21,6 @@ class TesserocrRecognize(Processor):
         Performs the (text) recognition.
         """
         print(self.parameter)
-        if self.parameter['textequiv_level'] not in ['line', 'glyph']:
-            raise Exception("currently only implemented at the line/glyph level")
         model = get_languages()[1][-1] # last installed model
         if 'model' in self.parameter:
             model = self.parameter['model']
@@ -38,41 +37,119 @@ class TesserocrRecognize(Processor):
                 # TODO slow
                 #  tessapi.SetPageSegMode(PSM.SINGLE_LINE)
                 log.info("page %s", pcgts)
-                for region in pcgts.get_Page().get_TextRegion():
+                page = pcgts.get_Page()
+                if self.parameter['textequiv_level'] == 'page':
+                    # not sure what to do here: 
+                    # - We cannot simply do GetUTF8Text(), because there is no TextEquiv on the page level.
+                    # - We could GetComponentImages(RIL.BLOCK) and add a text region for each, then enter region level recognition below. But what if regions are already annotated? How to go about non-text blocks?
+                    raise Exception("currently only implemented below the page level")
+                ## region, line, word, or glyph level:
+                regions = page.get_TextRegion()
+                if not regions:
+                    log.warn("Page contains no text regions") 
+                for region in regions:
+                    log.debug("Recognizing text in region '%s'", region.id)
+                    if self.parameter['textequiv_level'] == 'region':
+                        region_xywh = xywh_from_points(region.get_Coords().points)
+                        tessapi.SetRectangle(region_xywh['x'], region_xywh['y'], region_xywh['w'], region_xywh['h'])
+                        tessapi.SetPageSegMode(PSM.AUTO)
+                        if region.get_TextEquiv():
+                            log.warn("Region %s already contains text results", region.id)
+                        region.add_TextEquiv(TextEquivType(Unicode=tessapi.GetUTF8Text()))
+                        continue
+                    ## line, word, or glyph level:
                     textlines = region.get_TextLine()
-                    log.info("About to recognize text in %i lines of region '%s'", len(textlines), region.id)
+                    if not textlines:
+                        log.warn("Region contains no text lines.")
                     for line in textlines:
                         log.debug("Recognizing text in line '%s'", line.id)
-                        xywh = xywh_from_points(line.get_Coords().points)
-                        tessapi.SetRectangle(xywh['x'], xywh['y'], xywh['w'], xywh['h'])
-                        tessapi.SetPageSegMode(PSM.SINGLE_LINE)
-                        #  log.debug("xywh: %s", xywh)
+                        line_xywh = xywh_from_points(line.get_Coords().points)
+                        #  log.debug("xywh: %s", line_xywh)
+                        tessapi.SetRectangle(line_xywh['x'], line_xywh['y'], line_xywh['w'], line_xywh['h'])
+                        tessapi.SetPageSegMode(PSM.SINGLE_LINE) # RAW_LINE fails with Tesseract 3 models and is worse with Tesseract 4 models
+                        if self.parameter['textequiv_level'] == 'line':
+                            if line.get_TextEquiv():
+                                log.warn("Line %s already contains text results", line.id)
+                            #  tessapi.G
+                            line_conf = 1.0
+                            for (word_no, conf) in enumerate(tessapi.AllWordConfidences()):
+                                line_conf *= conf/100.0
+                            line.add_TextEquiv(TextEquivType(Unicode=tessapi.GetUTF8Text(), conf=line_conf))
+                            # maybe add TextEquiv alternatives via ChoiceIterator for TEXTLINE?
+                            continue
+                        ## word, or glyph level:
+                        # add line annotation unconditionally (i.e. even for word or glyph level):
                         line.add_TextEquiv(TextEquivType(Unicode=tessapi.GetUTF8Text()))
-                        #  tessapi.G
-                        #  print(tessapi.AllWordConfidences())
-                        if self.parameter['textequiv_level'] == 'glyph':
-                            for word in line.get_Word():
-                                log.debug("Recognizing text in word '%s'", word.id)
-                                xywh = xywh_from_points(word.get_Coords().points)
-                                tessapi.SetRectangle(xywh['x'], xywh['y'], xywh['w'], xywh['h'])
-                                tessapi.SetPageSegMode(PSM.SINGLE_WORD)
-                                word.add_TextEquiv(TextEquivType(Unicode=tessapi.GetUTF8Text()))
-                                result_it = tessapi.GetIterator()
-                                for (result_no, result) in enumerate(iterate_level(result_it, RIL.SYMBOL)):
-                                    #symb = result.GetUTF8Text(RIL.SYMBOL) # is first choice?
-                                    #conf = result.Confidence(RIL.SYMBOL) # is first choice?
-                                    bbox = result.BoundingBox(RIL.SYMBOL)
-                                    if bbox == None:
-                                        continue
-                                    glyph_id = '%s_glyph%04d' % (word.id, result_no)
+                        if line.get_Word():
+                            raise Exception("existing annotation for Word level would clash with OCR results for line '%s'", line.id) # forcing external layout annotation for words or glyphs is worse with Tesseract
+                        result_it = tessapi.GetIterator()
+                        for word_no in range(0,500): # iterate until IsAtFinalElement(RIL.LINE, RIL.WORD)
+                            if result_it.Empty(RIL.WORD):
+                                log.debug("No word here")
+                                break
+                            word_id = '%s_word%04d' % (line.id, word_no)
+                            log.debug("Recognizing text in word '%s'", word_id)
+                            word_bbox = result_it.BoundingBox(RIL.WORD)
+                            word = WordType(id=word_id, Coords=CoordsType(points_from_x0y0x1y1(word_bbox)))
+                            line.add_Word(word)
+                            word_attributes = result_it.WordFontAttributes()
+                            if word_attributes:
+                                word_style = TextStyleType(fontSize=word_attributes['pointsize'] if 'pointsize' in word_attributes else None,
+                                                           fontFamily=word_attributes['font_name'] if 'font_name' in word_attributes else None,
+                                                           bold=None if 'bold' not in word_attributes else word_attributes['bold'],
+                                                           italic=None if 'italic' not in word_attributes else word_attributes['italic'],
+                                                           underlined=None if 'underlined' not in word_attributes else word_attributes['underlined'],
+                                                           monospace=None if 'monospace' not in word_attributes else word_attributes['monospace'],
+                                                           serif=None if 'serif' not in word_attributes else word_attributes['serif']
+                                                           )
+                                word.set_TextStyle(word_style) # (or somewhere in custom attribute?)
+                            # word_type = result_it.BlockType()
+                            # PT.UNKNOWN
+                            # PT.FLOWING_TEXT
+                            # PT.HEADING_TEXT
+                            # PT.PULLOUT_TEXT
+                            # PT.EQUATION
+                            # PT.TABLE
+                            # PT.VERTICAL_TEXT
+                            # PT.CAPTION_TEXT
+                            # PT.HORZ_LINE
+                            # PT.VERT_LINE
+                            # PT.NOISE
+                            # PT.COUNT
+                            # ...
+                            # add word annotation unconditionally (i.e. even for glyph level):
+                            word.add_TextEquiv(TextEquivType(Unicode=result_it.GetUTF8Text(RIL.WORD), conf=result_it.Confidence(RIL.WORD)/100))
+                            if self.parameter['textequiv_level'] == 'word':
+                                pass
+                                # maybe add TextEquiv alternatives via ChoiceIterator for WORD?
+                            else:
+                                ## glyph level:
+                                for glyph_no in range(0,500): # iterate until IsAtFinalElement(RIL.WORD, RIL.SYMBOL)
+                                    if result_it.Empty(RIL.SYMBOL):
+                                        log.debug("No glyph here")
+                                        break
+                                    glyph_id = '%s_glyph%04d' % (word.id, glyph_no)
                                     log.debug("Recognizing text in glyph '%s'", glyph_id)
-                                    glyph = GlyphType(id=glyph_id, Coords=CoordsType(points_from_x0y0x1y1(bbox)))
+                                    glyph_symb = result_it.GetUTF8Text(RIL.SYMBOL) # equals first choice?
+                                    glyph_conf = result_it.Confidence(RIL.SYMBOL)/100 # equals first choice?
+                                    glyph_bbox = result_it.BoundingBox(RIL.SYMBOL)
+                                    glyph = GlyphType(id=glyph_id, Coords=CoordsType(points_from_x0y0x1y1(glyph_bbox)))
                                     word.add_Glyph(glyph)
-                                    choice_it = result.GetChoiceIterator()
+                                    choice_it = result_it.GetChoiceIterator()
                                     for (choice_no, choice) in enumerate(choice_it):
                                         alternative_symb = choice.GetUTF8Text()
-                                        alternative_conf = choice.Confidence()
+                                        alternative_conf = choice.Confidence()/100
+                                        if glyph_conf-alternative_conf > 0.2 or choice_no > 6:
+                                            break
                                         glyph.add_TextEquiv(TextEquivType(index=choice_no, conf=alternative_conf, Unicode=alternative_symb))
+                                    if result_it.IsAtFinalElement(RIL.WORD, RIL.SYMBOL):
+                                        break
+                                    else:
+                                        result_it.Next(RIL.SYMBOL)
+                            if result_it.IsAtFinalElement(RIL.TEXTLINE, RIL.WORD):
+                                break
+                            else:
+                                result_it.Next(RIL.WORD)
                 ID = concat_padded(self.output_file_grp, n)
                 self.add_output_file(
                     ID=ID,

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from tesserocr import RIL, PSM, PyTessBaseAPI, PyResultIterator, get_languages, iterate_level
 from ocrd.utils import getLogger, concat_padded, xywh_from_points, points_from_xywh, points_from_x0y0x1y1
 from ocrd.model.ocrd_page import from_file, to_xml, TextEquivType, CoordsType, GlyphType, WordType
-from ocrd.model.ocrd_page_generateds import TextStyleType
+from ocrd.model.ocrd_page_generateds import TextStyleType, MetadataItemType, LabelsType, LabelType
 from ocrd import Processor, MIMETYPE_PAGE
 from ocrd_tesserocr.config import TESSDATA_PREFIX, OCRD_TOOL
 
@@ -83,6 +83,15 @@ class TesserocrRecognize(Processor):
                 # TODO use binarized / gray
                 pil_image = self.workspace.resolve_image_as_pil(pcgts.get_Page().imageFilename)
                 tessapi.SetImage(pil_image)
+                metadata = pcgts.get_Metadata() # ensured by from_file()
+                metadata.add_MetadataItem(
+                    MetadataItemType(type_="processingStep",
+                                     name=OCRD_TOOL['tools']['ocrd-tesserocr-recognize']['steps'][0],
+                                     value='ocrd-tesserocr-recognize',
+                                     Labels=[LabelsType(externalRef="parameters",
+                                                        Label=[LabelType(type_=name,
+                                                                         value=self.parameter[name])
+                                                               for name in self.parameter.keys()])]))
                 # TODO slow
                 #  tessapi.SetPageSegMode(PSM.SINGLE_LINE)
                 log.info("Recognizing text in page '%s'", pcgts.get_pcGtsId())

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -113,7 +113,7 @@ class TesserocrRecognize(Processor):
                         tessapi.SetPageSegMode(PSM.SINGLE_BLOCK)
                         if region.get_TextEquiv():
                             log.warn("Region '%s' already contains text results", region.id)
-                        region.add_TextEquiv(TextEquivType(Unicode=tessapi.GetUTF8Text().strip()))
+                        region.add_TextEquiv(TextEquivType(Unicode=tessapi.GetUTF8Text().rstrip("\n\f")))
                         continue # next region (to avoid indentation below)
                     ## line, word, or glyph level:
                     textlines = region.get_TextLine()
@@ -132,7 +132,7 @@ class TesserocrRecognize(Processor):
                         for (word_no, conf) in enumerate(tessapi.AllWordConfidences()): # or tessapi.MeanTextConf()?
                             line_conf *= conf/100.0
                         # add line annotation unconditionally (i.e. even for word or glyph level):
-                        line.add_TextEquiv(TextEquivType(Unicode=tessapi.GetUTF8Text().strip(), conf=line_conf))
+                        line.add_TextEquiv(TextEquivType(Unicode=tessapi.GetUTF8Text().rstrip("\n\f"), conf=line_conf))
                         if maxlevel == 'line':
                             # maybe add TextEquiv alternatives via ChoiceIterator for TEXTLINE?
                             continue # next line (to avoid indentation below)
@@ -150,7 +150,7 @@ class TesserocrRecognize(Processor):
                                 if word.get_TextEquiv():
                                     log.warn("Word '%s' already contains text results", word.id)
                                 word_conf = tessapi.AllWordConfidences()[0]/100.0
-                                word.add_TextEquiv(TextEquivType(Unicode=tessapi.GetUTF8Text().strip(), conf=word_conf))
+                                word.add_TextEquiv(TextEquivType(Unicode=tessapi.GetUTF8Text().rstrip("\n\f"), conf=word_conf))
                                 if maxlevel == 'word':
                                     # maybe add TextEquiv alternatives via ChoiceIterator for WORD?
                                     continue # next word (to avoid indentation below)
@@ -168,7 +168,7 @@ class TesserocrRecognize(Processor):
                                         if glyph.get_TextEquiv():
                                             log.warn("Glyph '%s' already contains text results", glyph.id)
                                         glyph_conf = tessapi.AllWordConfidences()[0]/100.0
-                                        glyph.add_TextEquiv(TextEquivType(Unicode=tessapi.GetUTF8Text().strip(), conf=glyph_conf))
+                                        glyph.add_TextEquiv(TextEquivType(Unicode=tessapi.GetUTF8Text().rstrip("\n\f"), conf=glyph_conf))
                                         # maybe add TextEquiv alternatives via ChoiceIterator for SYMBOL?
                                     continue # next word (to avoid indentation below)
                                 ## internal glyph layout:

--- a/ocrd_tesserocr/segment_line.py
+++ b/ocrd_tesserocr/segment_line.py
@@ -42,7 +42,7 @@ class TesserocrSegmentLine(Processor):
                         line_points = points_from_xywh(line_xywh)
                         region.add_TextLine(TextLineType(id=line_id, Coords=CoordsType(line_points)))
                 ID = concat_padded(self.output_file_grp, n)
-                self.add_output_file(
+                self.workspace.add_file(
                     ID=ID,
                     file_grp=self.output_file_grp,
                     basename=ID + '.xml',

--- a/ocrd_tesserocr/segment_region.py
+++ b/ocrd_tesserocr/segment_region.py
@@ -61,7 +61,7 @@ class TesserocrSegmentRegion(Processor):
                     pcgts.get_Page().add_TextRegion(TextRegionType(id=ID, Coords=CoordsType(points=points)))
 
                 ID = concat_padded(self.output_file_grp, n)
-                self.add_output_file(
+                self.workspace.add_file(
                     ID=ID,
                     file_grp=self.output_file_grp,
                     basename=ID + '.xml',

--- a/ocrd_tesserocr/segment_word.py
+++ b/ocrd_tesserocr/segment_word.py
@@ -44,7 +44,7 @@ class TesserocrSegmentWord(Processor):
                             word_xywh['y'] += offset['y']
                             line.add_Word(WordType(id=word_id, Coords=CoordsType(points_from_xywh(word_xywh))))
                 ID = concat_padded(self.output_file_grp, n)
-                self.add_output_file(
+                self.workspace.add_file(
                     ID=ID,
                     file_grp=self.output_file_grp,
                     basename=ID + '.xml',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with codecs.open('README.rst', encoding='utf-8') as f:
 
 setup(
     name='ocrd_tesserocr',
-    version='0.0.1',
+    version='0.1.0',
     description='Tesserocr bindings',
     long_description=README,
     author='Konstantin Baierer',

--- a/test/test_recognize.py
+++ b/test/test_recognize.py
@@ -4,6 +4,7 @@ import shutil
 from test.base import TestCase, main, assets, skip
 
 from ocrd.resolver import Resolver
+from ocrd_tesserocr.segment_word import TesserocrSegmentWord
 from ocrd_tesserocr.segment_line import TesserocrSegmentLine
 from ocrd_tesserocr.segment_region import TesserocrSegmentRegion
 from ocrd_tesserocr.recognize import TesserocrRecognize
@@ -17,7 +18,7 @@ class TestTesserocrRecognize(TestCase):
             shutil.rmtree(WORKSPACE_DIR)
         os.makedirs(WORKSPACE_DIR)
 
-    skip("Takes too long")
+    #skip("Takes too long")
     def runTest(self):
         resolver = Resolver()
         #  workspace = resolver.workspace_from_url(assets.url_of('SBB0000F29300010000/mets_one_file.xml'), directory=WORKSPACE_DIR)
@@ -38,7 +39,20 @@ class TestTesserocrRecognize(TestCase):
             workspace,
             input_file_grp="OCR-D-SEG-LINE",
             output_file_grp="OCR-D-OCR-TESS",
-            parameter={'textequiv_level': 'line'}
+            parameter={'textequiv_level': 'line'} # add dep tesseract-ocr-script-frak: , 'model': 'Fraktur'
+        ).process()
+        workspace.save_mets()
+        TesserocrSegmentWord(
+            workspace,
+            input_file_grp="OCR-D-SEG-LINE",
+            output_file_grp="OCR-D-SEG-WORD"
+        ).process()
+        workspace.save_mets()
+        TesserocrRecognize(
+            workspace,
+            input_file_grp="OCR-D-SEG-WORD",
+            output_file_grp="OCR-D-OCR-TESS-W2C",
+            parameter={'textequiv_level': 'glyph'} # add dep tesseract-ocr-script-frak: , 'model': 'Fraktur'}
         ).process()
         workspace.save_mets()
 

--- a/test/test_segment_line.py
+++ b/test/test_segment_line.py
@@ -11,7 +11,7 @@ METS_HEROLD_SMALL = assets.url_of('SBB0000F29300010000/mets_one_file.xml')
 
 WORKSPACE_DIR = '/tmp/pyocrd-test-segment-line-tesserocr'
 
-class TestProcessorSegmentLineTesseract3(TestCase):
+class TestProcessorSegmentLineTesseract(TestCase):
 
     def setUp(self):
         if os.path.exists(WORKSPACE_DIR):

--- a/test/test_segment_region.py
+++ b/test/test_segment_region.py
@@ -1,14 +1,26 @@
+import os
+import shutil
+
 from test.base import TestCase, main, assets
 
 from ocrd.resolver import Resolver
 from ocrd_tesserocr.segment_region import TesserocrSegmentRegion
 
-class TestTesserocrRecognize(TestCase):
+METS_HEROLD_SMALL = assets.url_of('SBB0000F29300010000/mets_one_file.xml')
 
+WORKSPACE_DIR = '/tmp/pyocrd-test-segment-region-tesserocr'
+
+class TestTesserocrSegmentRegionTesseract(TestCase):
+    
+    def setUp(self):
+        if os.path.exists(WORKSPACE_DIR):
+            shutil.rmtree(WORKSPACE_DIR)
+        os.makedirs(WORKSPACE_DIR)
+    
     def runTest(self):
         resolver = Resolver()
-        workspace = resolver.workspace_from_url(assets.url_of('SBB0000F29300010000/mets_one_file.xml'))
-        TesserocrSegmentRegion(workspace).process()
+        workspace = resolver.workspace_from_url(METS_HEROLD_SMALL, directory=WORKSPACE_DIR)
+        TesserocrSegmentRegion(workspace, input_file_grp="INPUT", output_file_grp="OCR-D-SEG-BLOCK").process()
         workspace.save_mets()
 
 if __name__ == '__main__':

--- a/test/test_segment_word.py
+++ b/test/test_segment_word.py
@@ -10,7 +10,7 @@ from ocrd_tesserocr.segment_word import TesserocrSegmentWord
 
 WORKSPACE_DIR = '/tmp/pyocrd-test-segment-word-tesserocr'
 
-class TestProcessorSegmentWordTesseract3(TestCase):
+class TestProcessorSegmentWordTesseract(TestCase):
 
     def setUp(self):
         if os.path.exists(WORKSPACE_DIR):

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py27,py3{4,6.0}
+
+[testenv]
+passenv = HTTP_PROXY http_proxy HTTPS_PROXY https_proxy NO_PROXY no_proxy
+whitelist_externals= make
+deps =
+    -rrequirements.txt
+    -rrequirements_test.txt
+commands =
+    - make test


### PR DESCRIPTION
This is an attempt to implement the other annotation levels. In my opinion, the behaviour for the different levels cannot be made completely analogous with Tesseract: simply pointing it to rectangles for words and glyphs (from an external layout segmentation) would produce results of far worse quality than always recognizing one complete line and allowing its own segmentation below it (accessible by iterators). In contrast, from the line level upwards we can reliably use its respective page segmentation mode (SINGLE_LINE / SINGLE_BLOCK / AUTO). 
Perhaps warnings and exceptions should be dealt with in a different, more systematic way though.