### PR TITLE
repair automated build and tests:

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,12 @@
 !Makefile
 !setup.py
 !requirements.txt
+!requirements_test.txt
 !LICENSE
 !README.rst
 
-!ocrd_tesserocr
+# avoid .git and __pycache__ etc:
+!ocrd_tesserocr/**/*.py
+!ocrd_tesserocr/**/*.json
+!test/**/*.py
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV LANG C.UTF-8
 WORKDIR /build-ocrd
 COPY setup.py .
 COPY requirements.txt .
+COPY requirements_test.txt .
 COPY README.rst .
 COPY LICENSE .
 RUN apt-get update && \
@@ -18,18 +19,10 @@ RUN apt-get update && \
     git
 COPY Makefile .
 RUN make deps-ubuntu
-RUN sudo make patch-header
-RUN git clone https://github.com/sirfz/tesserocr && \
-    cd tesserocr && \
-    python3 setup.py install && \
-    cd .. && \
-    mkdir data
-RUN git clone https://github.com/OCR-D/core && \
-    cd core && \
-    python3 setup.py install && \
-    cd ..
 COPY ocrd_tesserocr ./ocrd_tesserocr
 RUN pip3 install --upgrade pip
-RUN make deps-pip install
+RUN make PYTHON=python3 PIP=pip3 deps install
+COPY test ./test
+RUN make PYTHON=python3 PIP=pip3 deps-test
 
 ENTRYPOINT ["/bin/sh", "-c"]

--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -7,6 +7,15 @@
       "executable": "ocrd-tesserocr-recognize",
       "categories": ["Text recognition and optimization"],
       "description": "Recognize text in lines with tesseract",
+      "input_file_grp": [
+        "OCR-D-SEG-BLOCK",
+        "OCR-D-SEG-LINE",
+        "OCR-D-SEG-WORD",
+        "OCR-D-SEG-GLYPH"
+      ],
+      "output_file_grp": [
+        "OCR-D-OCR-TESS"
+      ],
       "steps": ["recognition/text-recognition"],
       "parameters": {
         "textequiv_level": {
@@ -25,6 +34,12 @@
       "executable": "ocrd-tesserocr-segment-region",
       "categories": ["Layout analysis"],
       "description": "Segment regions into lines with tesseract",
+      "input_file_grp": [
+        "OCR-D-IMG"
+      ],
+      "output_file_grp": [
+        "OCR-D-SEG-BLOCK"
+      ],
       "steps": ["layout/segmentation/region"],
       "parameters": {}
     },
@@ -32,6 +47,12 @@
       "executable": "ocrd-tesserocr-segment-line",
       "categories": ["Layout analysis"],
       "description": "Segment page into regions with tesseract",
+      "input_file_grp": [
+        "OCR-D-SEG-BLOCK"
+      ],
+      "output_file_grp": [
+        "OCR-D-SEG-LINE"
+      ],
       "steps": ["layout/segmentation/line"],
       "parameters": {}
     },
@@ -39,6 +60,12 @@
       "executable": "ocrd-tesserocr-segment-word",
       "categories": ["Layout analysis"],
       "description": "Segment lines into words with tesseract",
+      "input_file_grp": [
+        "OCR-D-SEG-LINE"
+      ],
+      "output_file_grp": [
+        "OCR-D-SEG-WORD"
+      ],
       "steps": ["layout/segmentation/word"],
       "parameters": {}
     }

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -178,6 +178,7 @@ class TesserocrRecognize(Processor):
                 self._process_existing_words(words, maxlevel, tessapi)
             else:
                 ## internal word and glyph layout:
+                tessapi.Recognize()
                 self._process_words_in_line(line, maxlevel, tessapi.GetIterator())
 
     def _process_words_in_line(self, line, maxlevel, result_it):
@@ -240,6 +241,7 @@ class TesserocrRecognize(Processor):
                 self._process_existing_glyphs(glyphs, tessapi)
             else:
                 ## internal glyph layout:
+                tessapi.Recognize()
                 self._process_glyphs_in_word(word, tessapi.GetIterator())
 
     def _process_existing_glyphs(self, glyphs, tessapi):

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -139,9 +139,13 @@ class TesserocrRecognize(Processor):
                 region_xywh = xywh_from_points(region.get_Coords().points)
                 tessapi.SetRectangle(region_xywh['x'], region_xywh['y'], region_xywh['w'], region_xywh['h'])
                 tessapi.SetPageSegMode(PSM.SINGLE_BLOCK)
+                region_text = tessapi.GetUTF8Text().rstrip("\n\f")
+                region_conf = tessapi.MeanTextConf()/100.0 # iterator scores are arithmetic averages, too
                 if region.get_TextEquiv():
-                    log.warning("Region '%s' already contains text results", region.id)
-                region.add_TextEquiv(TextEquivType(Unicode=tessapi.GetUTF8Text().rstrip("\n\f")))
+                    log.warning("Region '%s' already contained text results", region.id)
+                    region.set_TextEquiv([])
+                # todo: consider SetParagraphSeparator
+                region.add_TextEquiv(TextEquivType(Unicode=region_text, conf=region_conf))
                 continue # next region (to avoid indentation below)
             ## line, word, or glyph level:
             textlines = region.get_TextLine()
@@ -157,26 +161,26 @@ class TesserocrRecognize(Processor):
             #  log.debug("xywh: %s", line_xywh)
             tessapi.SetRectangle(line_xywh['x'], line_xywh['y'], line_xywh['w'], line_xywh['h'])
             tessapi.SetPageSegMode(PSM.SINGLE_LINE) # RAW_LINE fails with Tesseract 3 models and is worse with Tesseract 4 models
-            if line.get_TextEquiv():
-                log.warning("Line '%s' already contains text results", line.id)
-            line_conf = tessapi.MeanTextConf()/100.0 # iterator scores are arithmetic averages, too
-            # add line annotation unconditionally (i.e. even for word or glyph level):
-            line.add_TextEquiv(TextEquivType(Unicode=tessapi.GetUTF8Text().rstrip("\n\f"), conf=line_conf))
             if maxlevel == 'line':
+                line_text = tessapi.GetUTF8Text().rstrip("\n\f")
+                line_conf = tessapi.MeanTextConf()/100.0 # iterator scores are arithmetic averages, too
+                if line.get_TextEquiv():
+                    log.warning("Line '%s' already contained text results", line.id)
+                    line.set_TextEquiv([])
+                # todo: consider BlankBeforeWord, SetLineSeparator
+                line.add_TextEquiv(TextEquivType(Unicode=line_text, conf=line_conf))
                 continue # next line (to avoid indentation below)
             ## word, or glyph level:
             words = line.get_Word()
             if words:
                 ## external word layout:
-                # raise Exception("existing annotation for Word level would clash with OCR results for line '%s'", line.id) # forcing external layout annotation for words or glyphs is worse with Tesseract
                 log.warning("Line '%s' contains words already, recognition might be suboptimal", line.id)
                 self._process_existing_words(words, maxlevel, tessapi)
             else:
                 ## internal word and glyph layout:
-                self._process_words_in_line(line, maxlevel, tessapi)
+                self._process_words_in_line(line, maxlevel, tessapi.GetIterator())
 
-    def _process_words_in_line(self, line, maxlevel, tessapi):
-        result_it = tessapi.GetIterator()
+    def _process_words_in_line(self, line, maxlevel, result_it):
         for word_no in range(0, MAX_ELEMENTS): # iterate until IsAtFinalElement(RIL.LINE, RIL.WORD)
             if not result_it:
                 log.error("No iterator at '%s'", line.id)
@@ -218,18 +222,20 @@ class TesserocrRecognize(Processor):
             word_xywh = xywh_from_points(word.get_Coords().points)
             tessapi.SetRectangle(word_xywh['x'], word_xywh['y'], word_xywh['w'], word_xywh['h'])
             tessapi.SetPageSegMode(PSM.SINGLE_WORD)
-            if word.get_TextEquiv():
-                log.warning("Word '%s' already contains text results", word.id)
-            word_conf = tessapi.AllWordConfidences()
-            word_conf = word_conf[0]/100.0 if word_conf else 0.0
-            word.add_TextEquiv(TextEquivType(Unicode=tessapi.GetUTF8Text().rstrip("\n\f"), conf=word_conf))
             if maxlevel == 'word':
+                word_text = tessapi.GetUTF8Text().rstrip("\n\f")
+                word_conf = tessapi.AllWordConfidences()
+                word_conf = word_conf[0]/100.0 if word_conf else 0.0
+                if word.get_TextEquiv():
+                    log.warning("Word '%s' already contained text results", word.id)
+                    word.set_TextEquiv([])
+                # todo: consider WordFontAttributes (TextStyle) etc (if not word.get_TextStyle())
+                word.add_TextEquiv(TextEquivType(Unicode=word_text, conf=word_conf))
                 continue # next word (to avoid indentation below)
             ## glyph level:
             glyphs = word.get_Glyph()
             if glyphs:
                 ## external glyph layout:
-                # raise Exception("existing annotation for Glyph level would clash with OCR results for word '%s'", word.id) # forcing external layout annotation for gylphs is worse with Tesseract
                 log.warning("Word '%s' contains glyphs already, recognition might be suboptimal", word.id)
                 self._process_existing_glyphs(glyphs, tessapi)
             else:
@@ -243,24 +249,26 @@ class TesserocrRecognize(Processor):
             tessapi.SetRectangle(glyph_xywh['x'], glyph_xywh['y'], glyph_xywh['w'], glyph_xywh['h'])
             tessapi.SetPageSegMode(PSM.SINGLE_CHAR)
             if glyph.get_TextEquiv():
-                log.warning("Glyph '%s' already contains text results", glyph.id)
-            #glyph_symb = tessapi.GetUTF8Text().rstrip("\n\f")
+                log.warning("Glyph '%s' already contained text results", glyph.id)
+                glyph.set_TextEquiv([])
+            #glyph_text = tessapi.GetUTF8Text().rstrip("\n\f")
             glyph_conf = tessapi.AllWordConfidences()
             glyph_conf = glyph_conf[0]/100.0 if glyph_conf else 0.0
-            #log.debug('best glyph: "%s" [%f]', glyph_symb, glyph_conf)
+            #log.debug('best glyph: "%s" [%f]', glyph_text, glyph_conf)
             result_it = tessapi.GetIterator()
             if not result_it or result_it.Empty(RIL.SYMBOL):
                 log.error("No glyph here")
                 continue
             choice_it = result_it.GetChoiceIterator()
             for (choice_no, choice) in enumerate(choice_it):
-                alternative_symb = choice.GetUTF8Text()
+                alternative_text = choice.GetUTF8Text()
                 alternative_conf = choice.Confidence()/100
-                #log.debug('alternative glyph: "%s" [%f]', alternative_symb, alternative_conf)
+                #log.debug('alternative glyph: "%s" [%f]', alternative_text, alternative_conf)
                 if (glyph_conf - alternative_conf > CHOICE_THRESHOLD_CONF or
                     choice_no > CHOICE_THRESHOLD_NUM):
                     break
-                glyph.add_TextEquiv(TextEquivType(index=choice_no, conf=alternative_conf, Unicode=alternative_symb))
+                # todo: consider SymbolIsSuperscript (TextStyle), SymbolIsDropcap (RelationType) etc
+                glyph.add_TextEquiv(TextEquivType(index=choice_no, Unicode=alternative_text, conf=alternative_conf))
     
     def _process_glyphs_in_word(self, word, result_it):
         for glyph_no in range(0, MAX_ELEMENTS): # iterate until IsAtFinalElement(RIL.WORD, RIL.SYMBOL)
@@ -272,21 +280,22 @@ class TesserocrRecognize(Processor):
                 break
             glyph_id = '%s_glyph%04d' % (word.id, glyph_no)
             log.debug("Recognizing text in glyph '%s'", glyph_id)
-            #  glyph_symb = result_it.GetUTF8Text(RIL.SYMBOL) # equals first choice?
+            #  glyph_text = result_it.GetUTF8Text(RIL.SYMBOL) # equals first choice?
             glyph_conf = result_it.Confidence(RIL.SYMBOL)/100 # equals first choice?
-            #log.debug('best glyph: "%s" [%f]', glyph_symb, glyph_conf)
+            #log.debug('best glyph: "%s" [%f]', glyph_text, glyph_conf)
             glyph_bbox = result_it.BoundingBox(RIL.SYMBOL)
             glyph = GlyphType(id=glyph_id, Coords=CoordsType(points_from_x0y0x1y1(glyph_bbox)))
             word.add_Glyph(glyph)
             choice_it = result_it.GetChoiceIterator()
             for (choice_no, choice) in enumerate(choice_it):
-                alternative_symb = choice.GetUTF8Text()
+                alternative_text = choice.GetUTF8Text()
                 alternative_conf = choice.Confidence()/100
-                #log.debug('alternative glyph: "%s" [%f]', alternative_symb, alternative_conf)
+                #log.debug('alternative glyph: "%s" [%f]', alternative_text, alternative_conf)
                 if (glyph_conf - alternative_conf > CHOICE_THRESHOLD_CONF or
                     choice_no > CHOICE_THRESHOLD_NUM):
                     break
-                glyph.add_TextEquiv(TextEquivType(index=choice_no, conf=alternative_conf, Unicode=alternative_symb))
+                # todo: consider SymbolIsSuperscript (TextStyle), SymbolIsDropcap (RelationType) etc
+                glyph.add_TextEquiv(TextEquivType(index=choice_no, Unicode=alternative_text, conf=alternative_conf))
             if result_it.IsAtFinalElement(RIL.WORD, RIL.SYMBOL):
                 break
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ocrd >= 0.7.2
+ocrd >= 0.15.0
 click
-tesserocr >= 2.3.0
+tesserocr == 2.3.1

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages=find_packages(exclude=('tests', 'docs')),
     install_requires=[
         'ocrd >= 0.15.0',
-        'tesserocr >= 2.3.0',
+        'tesserocr >= 2.3.1',
         'click',
     ],
     package_data={

--- a/test/test_recognize.py
+++ b/test/test_recognize.py
@@ -9,6 +9,9 @@ from ocrd_tesserocr.segment_line import TesserocrSegmentLine
 from ocrd_tesserocr.segment_region import TesserocrSegmentRegion
 from ocrd_tesserocr.recognize import TesserocrRecognize
 
+#METS_HEROLD_SMALL = assets.url_of('SBB0000F29300010000/data/mets_one_file.xml')
+METS_HEROLD_SMALL = assets.url_of('kant_aufklaerung_1784/data/mets.xml')
+
 WORKSPACE_DIR = '/tmp/pyocrd-test-recognizer'
 
 class TestTesserocrRecognize(TestCase):
@@ -21,8 +24,7 @@ class TestTesserocrRecognize(TestCase):
     #skip("Takes too long")
     def runTest(self):
         resolver = Resolver()
-        #  workspace = resolver.workspace_from_url(assets.url_of('SBB0000F29300010000/data/mets_one_file.xml'), src_dir=WORKSPACE_DIR)
-        workspace = resolver.workspace_from_url(assets.url_of('kant_aufklaerung_1784/data/mets.xml'), src_dir=WORKSPACE_DIR)
+        workspace = resolver.workspace_from_url(METS_HEROLD_SMALL, dst_dir=WORKSPACE_DIR)
         TesserocrSegmentRegion(
             workspace,
             input_file_grp="OCR-D-IMG",

--- a/test/test_recognize.py
+++ b/test/test_recognize.py
@@ -22,7 +22,7 @@ class TestTesserocrRecognize(TestCase):
     def runTest(self):
         resolver = Resolver()
         #  workspace = resolver.workspace_from_url(assets.url_of('SBB0000F29300010000/data/mets_one_file.xml'), src_dir=WORKSPACE_DIR)
-        workspace = resolver.workspace_from_url(assets.url_of('kant_aufklaerung_1784-page-block-line-word/data/mets.xml'), src_dir=WORKSPACE_DIR)
+        workspace = resolver.workspace_from_url(assets.url_of('kant_aufklaerung_1784/data/mets.xml'), src_dir=WORKSPACE_DIR)
         TesserocrSegmentRegion(
             workspace,
             input_file_grp="OCR-D-IMG",

--- a/test/test_segment_word.py
+++ b/test/test_segment_word.py
@@ -8,6 +8,9 @@ from ocrd_tesserocr.segment_region import TesserocrSegmentRegion
 from ocrd_tesserocr.segment_line import TesserocrSegmentLine
 from ocrd_tesserocr.segment_word import TesserocrSegmentWord
 
+#METS_HEROLD_SMALL = assets.url_of('SBB0000F29300010000/mets_one_file.xml')
+METS_HEROLD_SMALL = assets.url_of('kant_aufklaerung_1784-binarized/data/mets.xml')
+
 WORKSPACE_DIR = '/tmp/pyocrd-test-segment-word-tesserocr'
 
 class TestProcessorSegmentWordTesseract(TestCase):
@@ -19,8 +22,7 @@ class TestProcessorSegmentWordTesseract(TestCase):
 
     def runTest(self):
         resolver = Resolver()
-        #  workspace = resolver.workspace_from_url(assets.url_of('SBB0000F29300010000/mets_one_file.xml'), src_dir=WORKSPACE_DIR)
-        workspace = resolver.workspace_from_url(assets.url_of('kant_aufklaerung_1784-binarized/data/mets.xml'), src_dir=WORKSPACE_DIR)
+        workspace = resolver.workspace_from_url(METS_HEROLD_SMALL, dst_dir=WORKSPACE_DIR)
         TesserocrSegmentRegion(workspace, input_file_grp="OCR-D-IMG", output_file_grp="OCR-D-SEG-BLOCK").process()
         TesserocrSegmentLine(workspace, input_file_grp="OCR-D-SEG-BLOCK", output_file_grp="OCR-D-SEG-LINE").process()
         TesserocrSegmentWord(workspace, input_file_grp="OCR-D-SEG-LINE", output_file_grp="OCR-D-SEG-WORD").process()


### PR DESCRIPTION
- fix makefile and requirements:
  - remove patch-header (not applicable anymore)
  - reinstate ubuntu deps, also for tesseract itself
  - avoid tesserocr 2.4.0 because tesseract 4.0.0
    is not available via apt yet

- fix dockerfile:
  - remove patch-header (not applicable anymore)
  - do not install core (already in base container)
  - install tesserocr via pip instead of repo
  - make sure makefile recipes are run with python3
  - avoid copying cached/repo files
  - also install test environment

- fix tests:
  - update test-cli to new data/ convention
  - update test to renamed paths in assets repo