### PR TITLE
segment-region: use BlockPolygon

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 ocrd_tesserocr
 ==============
 
-    Segment region, line, recognize with tesserocr
+    Segment into regions or lines, deskew, or recognize with tesserocr
 
 .. image:: https://circleci.com/gh/OCR-D/ocrd_tesserocr.svg?style=svg
     :target: https://circleci.com/gh/OCR-D/ocrd_tesserocr
@@ -12,6 +12,17 @@ ocrd_tesserocr
 .. image:: https://img.shields.io/docker/automated/ocrd/tesserocr.svg
     :target: https://hub.docker.com/r/ocrd/tesserocr/tags/
     :alt: Docker Automated build
+
+Introduction
+------------
+
+This offers `OCR-D`_ compliant workspace processors for (much of) the functionality of `Tesseract`_ via its Python API wrapper `tesserocr`_ . (Each processor is a step in the OCR-D functional model, and can be replaced with an alternative implementation. Data is represented within METS/PAGE.)
+
+This includes image preprocessing (cropping, binarization, deskewing), layout analysis (region, line, word segmentation) and OCR proper. Most processors can operate on different levels of the PAGE hierarchy, depending on the workflow configuration. Image results are referenced (read and written) via ``AlternativeImage``, text results via ``TextEquiv``.
+
+.. _OCR-D: https://ocr-d.github.io
+.. _Tesseract: https://github.com/tesseract-ocr
+.. _tesserocr: https://github.com/sirfz/tesserocr
 
 
 Installation
@@ -25,8 +36,9 @@ Required ubuntu packages:
 
 ::
 
-    pip install -r requirements
-    pip install .
+    make deps-ubuntu # or manually
+    make deps # or pip install -r requirements
+    make install # or pip install .
 
 If tesserocr fails to compile with an error:::
 
@@ -43,3 +55,41 @@ mismatch between tesseract header/data/pkg-config versions. ``apt policy
 libtesseract-dev`` lists the apt-installable versions, keep it consistent. Make
 sure there are no spurious pkg-config artifacts, e.g. in
 ``/usr/local/lib/pkgconfig/tesseract.pc``. The same goes for language models.
+
+
+Usage
+-----
+
+See docstrings and in the individual processors and `ocrd-tool.json`_ descriptions.
+
+.. _ocrd-tool.json: ocrd_tesserocr/ocrd-tool.json
+
+Available processors are:
+
+- `ocrd-tesserocr-crop`_
+- `ocrd-tesserocr-deskew`_
+- `ocrd-tesserocr-binarize`_
+- `ocrd-tesserocr-segment-region`_
+- `ocrd-tesserocr-segment-line`_
+- `ocrd-tesserocr-segment-word`_
+- `ocrd-tesserocr-recognize`_
+
+.. _`ocrd-tesserocr-crop`: ocrd_tesserocr/crop.py
+.. _`ocrd-tesserocr-deskew`: ocrd_tesserocr/deskew.py
+.. _`ocrd-tesserocr-binarize`: ocrd_tesserocr/binarize.py
+.. _`ocrd-tesserocr-segment-region`: ocrd_tesserocr/segment_region.py
+.. _`ocrd-tesserocr-segment-line`: ocrd_tesserocr/segment_line.py
+.. _`ocrd-tesserocr-segment-word`: ocrd_tesserocr/segment_word.py
+.. _`ocrd-tesserocr-recognize`: ocrd_tesserocr/recognize.py
+
+
+Testing
+-------
+
+::
+
+    make test
+
+This downloads some test data from <https://github.com/OCR-D/assets> under ``repo/assets``, and runs some basic test of the Python API as well as the CLIs.
+
+Set ``PYTEST_ARGS="-s --verbose"`` to see log output (``-s``) and individual test results (``--verbose``).

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 ocrd_tesserocr
 ==============
 
-    Segment into regions or lines, deskew, or recognize with tesserocr
+    Crop, deskew, segment into regions / lines / words, or recognize with tesserocr
 
 .. image:: https://circleci.com/gh/OCR-D/ocrd_tesserocr.svg?style=svg
     :target: https://circleci.com/gh/OCR-D/ocrd_tesserocr
@@ -18,7 +18,7 @@ Introduction
 
 This offers `OCR-D`_ compliant workspace processors for (much of) the functionality of `Tesseract`_ via its Python API wrapper `tesserocr`_ . (Each processor is a step in the OCR-D functional model, and can be replaced with an alternative implementation. Data is represented within METS/PAGE.)
 
-This includes image preprocessing (cropping, binarization, deskewing), layout analysis (region, line, word segmentation) and OCR proper. Most processors can operate on different levels of the PAGE hierarchy, depending on the workflow configuration. Image results are referenced (read and written) via ``AlternativeImage``, text results via ``TextEquiv``.
+This includes image preprocessing (cropping, binarization, deskewing), layout analysis (region, line, word segmentation) and OCR proper. Most processors can operate on different levels of the PAGE hierarchy, depending on the workflow configuration. Image results are referenced (read and written) via ``AlternativeImage``, text results via ``TextEquiv``, deskewing via ``@orientation``, cropping via ``Border`` and segmentation via ``Region`` / ``TextLine`` / ``Word`` elements with ``Coords/@points``.
 
 .. _OCR-D: https://ocr-d.github.io
 .. _Tesseract: https://github.com/tesseract-ocr

--- a/ocrd_tesserocr/common.py
+++ b/ocrd_tesserocr/common.py
@@ -525,6 +525,11 @@ def xywh_from_polygon(polygon):
     return xywh_from_bbox(*bbox_from_polygon(polygon))
 
 # to be refactored into core (as function in ocrd_utils):
+def polygon_from_xywh(xywh):
+    """Construct polygon coordinates in numeric list representation from numeric dict representing a bounding box."""
+    return polygon_from_bbox(*bbox_from_xywh(xywh))
+
+# to be refactored into core (as function in ocrd_utils):
 def bbox_from_polygon(polygon):
     """Construct a numeric list representing a bounding box from polygon coordinates in numeric list representation."""
     minx = sys.maxsize
@@ -541,6 +546,20 @@ def bbox_from_polygon(polygon):
         if xy[1] > maxy:
             maxy = xy[1]
     return minx, miny, maxx, maxy
+
+# to be refactored into core (as function in ocrd_utils):
+def polygon_from_bbox(minx, miny, maxx, maxy):
+    """Construct polygon coordinates in numeric list representation from a numeric list representing a bounding box."""
+    return [[minx, miny], [maxx, miny], [maxx, maxy], [minx, maxy]]
+
+# to be refactored into core (as function in ocrd_utils):
+def polygon_from_x0y0x1y1(x0y0x1y1):
+    """Construct polygon coordinates in numeric list representation from a string list representing a bounding box."""
+    minx = int(x0y0x1y1[0])
+    miny = int(x0y0x1y1[1])
+    maxx = int(x0y0x1y1[2])
+    maxy = int(x0y0x1y1[3])
+    return [[minx, miny], [maxx, miny], [maxx, maxy], [minx, maxy]]
 
 def membername(class_, val):
     """Convert a member variable/constant into a member name string."""

--- a/ocrd_tesserocr/crop.py
+++ b/ocrd_tesserocr/crop.py
@@ -125,12 +125,12 @@ class TesserocrCrop(Processor):
                     bin_bbox = image.getbbox()
                     if not bin_bbox:
                         # this does happen!
-                        LOG.debug("Ignoring region '%s' because its binarization is empty", ID)
+                        LOG.info("Ignoring region '%s' because its binarization is empty", ID)
                         continue
                     width = bin_bbox[2]-bin_bbox[0]
                     if width < 25 / zoom:
                         # we must be conservative here: page numbers are tiny regions, too!
-                        LOG.debug("Ignoring region '%s' because its width is too small (%d)", ID, width)
+                        LOG.info("Ignoring region '%s' because its width is too small (%d)", ID, width)
                         continue
                     height = bin_bbox[3]-bin_bbox[1]
                     if height < 25 / zoom:
@@ -141,7 +141,7 @@ class TesserocrCrop(Processor):
                     min_y = min(min_y, top)
                     max_x = max(max_x, right)
                     max_y = max(max_y, bottom)
-                    LOG.debug("Updated page border: %i:%i,%i:%i", min_x, max_x, min_y, max_y)
+                    LOG.info("Updated page border: %i:%i,%i:%i", min_x, max_x, min_y, max_y)
 
                 #
                 # set the identified page border
@@ -152,7 +152,7 @@ class TesserocrCrop(Processor):
                     max_x = min(max_x + padding, page_image.width)
                     min_y = max(min_y - padding, 0)
                     max_y = min(max_y + padding, page_image.height)
-                    LOG.debug("Padded page border: %i:%i,%i:%i", min_x, max_x, min_y, max_y)
+                    LOG.info("Padded page border: %i:%i,%i:%i", min_x, max_x, min_y, max_y)
                     border = BorderType(Coords=CoordsType(
                         points_from_bbox(min_x, min_y, max_x, max_y)))
                     # update PAGE (annotate border):

--- a/ocrd_tesserocr/deskew.py
+++ b/ocrd_tesserocr/deskew.py
@@ -159,7 +159,49 @@ class TesserocrDeskew(Processor):
                 LOG.info('applying OSD script  result "%s" with high confidence %.0f in %s',
                          osr['script_name'], osr['script_conf'], where)
                 if isinstance(segment, (TextRegionType, PageType)):
-                    segment.set_primaryScript(osr['script_name'])
+                    segment.set_primaryScript({
+                        "Arabic": "Arab - Arabic",
+                        "Armenian": "Armn - Armenian",
+                        "Bengali": "Armn - Armenian",
+                        "Canadian_Aboriginal": "Cans - Unified Canadian Aboriginal Syllabics",
+                        "Cherokee": "Cher - Cherokee",
+                        "Common": "Latn - Latin", # not in scripts/
+                        "Cyrillic": "Cyrl - Cyrillic",
+                        "Devanagari": "Deva - Devanagari (Nagari)",
+                        "Ethiopic": "Ethi - Ethiopic",
+                        "Fraktur": "Latf - Latin (Fraktur variant)",
+                        "Georgian": "Geor - Georgian (Mkhedruli)",
+                        "Greek": "Grek - Greek",
+                        "Gujarati": "Gujr - Gujarati",
+                        "Gurmukhi": "Guru - Gurmukhi",
+                        "Han": "Hant - Han (Traditional variant)", # not in scripts/
+                        "Hangul": "Hang - Hangul",
+                        "Hangul_vert": "Hang - Hangul",
+                        "HanS": "Hans - Han (Simplified variant)",
+                        "HanS_vert": "Hans - Han (Simplified variant)",
+                        "HanT": "Hant - Han (Traditional variant)",
+                        "HanT_vert": "Hant - Han (Traditional variant)",
+                        "Hebrew": "Hebr - Hebrew",
+                        "Hiragana": "Jpan - Japanese", # not in scripts/
+                        "Japanese": "Jpan - Japanese",
+                        "Japanese_vert": "Jpan - Japanese",
+                        "Kannada": "Knda - Kannada",
+                        "Katakana": "Jpan - Japanese", # not in scripts/
+                        "Khmer": "Khmr - Khmer",
+                        "Lao": "Laoo - Lao",
+                        "Latin": "Latn - Latin",
+                        "Malayalam": "Mlym - Malayalam",
+                        "Myanmar": "Mymr - Myanmar (Burmese)",
+                        "Oriya": "Orya - Oriya",
+                        "Sinhala": "Sinh - Sinhala",
+                        "Syriac": "Syrc - Syriac",
+                        "Tamil": "Taml - Tamil",
+                        "Telugu": "Telu - Telugu",
+                        "Thaana": "Thaa - Thaana",
+                        "Thai": "Thai - Thai",
+                        "Tibetan": "Tibt - Tibetan",
+                        "Vietnamese": "Tavt - Tai Viet",
+                    }.get(osr['script_name'], "Latn - Latin"))
         else:
             LOG.warning('no OSD result in %s', where)
         #

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ocrd >= 1.0.0b10
 click
-tesserocr@git+https://github.com/sirfz/tesserocr#egg=tesserocr-2.4.0
+ocrd-fork-tesserocr==3.0.0rc2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ocrd >= 1.0.0b5
+ocrd >= 1.0.0b10
 click
-tesserocr >= 2.3.1
+tesserocr@git+https://github.com/sirfz/tesserocr#egg=tesserocr-2.4.0


### PR DESCRIPTION
Now that sirfz/tesserocr#185 is merged, we can annotate Tesseract's polygon results instead of just the bounding box. Still not making `crop_polygons` true by default, because I believe these things cannot be trusted. 

I have linked with `tesserocr` requirement from Github instead of the PyPI pkg, because a new release will likely not arrive before Tesseract 5.