### PR TITLE
Catch exception when setting the locale

### DIFF
--- a/ocrd_tesserocr/__init__.py
+++ b/ocrd_tesserocr/__init__.py
@@ -1,10 +1,18 @@
 import locale
-# circumvent tesseract-ocr issue #1670
+# Circumvent tesseract-ocr issue #1670
 # (which cannot be done on command line
 # because Click requires an UTF-8 locale
-# in Python 3):
+# in Python 3).
+# Setting the locale is no longer needed with
+# Tesseract 4.1.0, 5.0.0-alpha or newer versions.
+# Setting the locale fails with Python 3.7 on macOS
+# so try running without a special locale if there
+# is an exception.
 # pylint: disable=wrong-import-position
-locale.setlocale(locale.LC_ALL, 'C.UTF-8')
+try:
+    locale.setlocale(locale.LC_ALL, 'C.UTF-8')
+except locale.Error:
+    pass
 
 from .recognize import TesserocrRecognize
 from .segment_word import TesserocrSegmentWord


### PR DESCRIPTION
Add also a comment that setting the locale is no longer needed
with newer versions of Tesseract.

Signed-off-by: Stefan Weil <sw@weilnetz.de>