### PR TITLE
Update requirements to replace ocrd-fork-tesserocr by tesserocr

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ocrd >= 1.0.0b17
 click
-ocrd-fork-tesserocr==3.0.0rc2
+tesserocr==2.4.1


### PR DESCRIPTION
Quoting @kba at https://gitter.im/OCR-D/Lobby?at=5d60879c3c1aba311bbebaa6:

"Upstream tesserocr 2.4.1 seems to work just fine, so we can scrap
ocrd-fork-tesserocr".

Signed-off-by: Stefan Weil <sw@weilnetz.de>