### PR TITLE
move to AlternativeImage feature selectors in OCR-D/core#294:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+  * Adapt to feature selection/filtering mechanism for derived images in core
+  * Fixes for image feature-related corner cases in crop and deskew
+  * Use explicit (second) output fileGrp when producing derived images
+
 ## [0.4.0] - 2019-08-21
 
 Changed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
   * Adapt to feature selection/filtering mechanism for derived images in core
-  * Fixes for image feature-related corner cases in crop and deskew
+  * Fixes for image-feature-related corner cases in crop and deskew
   * Use explicit (second) output fileGrp when producing derived images
 
 ## [0.4.0] - 2019-08-21

--- a/ocrd_tesserocr/binarize.py
+++ b/ocrd_tesserocr/binarize.py
@@ -49,7 +49,7 @@ class TesserocrBinarize(Processor):
         Set up Tesseract to recognize the segment image's layout, and get
         the binarized image. Create an image file, and reference it as
         AlternativeImage in the segment element. Add the new image file
-        to the workspace with with the fileGrp USE given in the second position
+        to the workspace with the fileGrp USE given in the second position
         of the output fileGrp, or ``OCR-D-IMG-BIN``, and an ID based on input
         file and input element.
         

--- a/ocrd_tesserocr/binarize.py
+++ b/ocrd_tesserocr/binarize.py
@@ -32,6 +32,13 @@ class TesserocrBinarize(Processor):
         kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         kwargs['version'] = OCRD_TOOL['version']
         super(TesserocrBinarize, self).__init__(*args, **kwargs)
+        if hasattr(self, 'output_file_grp'):
+            try:
+                self.page_grp, self.image_grp = self.output_file_grp.split(',')
+            except ValueError:
+                self.page_grp = self.output_file_grp
+                self.image_grp = FALLBACK_IMAGE_GRP
+                LOG.info("No output file group for images specified, falling back to '%s'", FALLBACK_IMAGE_GRP)
 
     def process(self):
         """Performs binarization of the region / line with Tesseract on the workspace.
@@ -41,37 +48,36 @@ class TesserocrBinarize(Processor):
         
         Set up Tesseract to recognize the segment image's layout, and get
         the binarized image. Create an image file, and reference it as
-        AlternativeImage in the element and as file with a fileGrp USE
-        equal `OCR-D-IMG-BIN` in the workspace.
+        AlternativeImage in the segment element. Add the new image file
+        to the workspace with with the fileGrp USE given in the second position
+        of the output fileGrp, or ``OCR-D-IMG-BIN``, and an ID based on input
+        file and input element.
         
         Produce a new output file by serialising the resulting hierarchy.
         """
-        # pylint: disable=attribute-defined-outside-init
-        try:
-            self.page_grp, self.image_grp = self.output_file_grp.split(',')
-        except ValueError:
-            self.page_grp = self.output_file_grp
-            self.image_grp = FALLBACK_IMAGE_GRP
-            LOG.info("No output file group for images specified, falling back to '%s'", FALLBACK_IMAGE_GRP)
         oplevel = self.parameter['operation_level']
+        
         with PyTessBaseAPI(path=TESSDATA_PREFIX) as tessapi:
             for n, input_file in enumerate(self.input_files):
                 file_id = input_file.ID.replace(self.input_file_grp, self.image_grp)
                 page_id = input_file.pageId or input_file.ID
                 LOG.info("INPUT FILE %i / %s", n, page_id)
                 pcgts = page_from_file(self.workspace.download_file(input_file))
+                page = pcgts.get_Page()
+                
+                # add metadata about this operation and its runtime parameters:
                 metadata = pcgts.get_Metadata() # ensured by from_file()
                 metadata.add_MetadataItem(
                     MetadataItemType(type_="processingStep",
                                      name=self.ocrd_tool['steps'][0],
                                      value=TOOL,
-                                     # FIXME: externalRef is invalid by pagecontent.xsd, but ocrd does not reflect this
-                                     # what we want here is `externalModel="ocrd-tool" externalId="parameters"`
-                                     Labels=[LabelsType(#externalRef="parameters",
-                                                        Label=[LabelType(type_=name,
-                                                                         value=self.parameter[name])
-                                                               for name in self.parameter.keys()])]))
-                page = pcgts.get_Page()
+                                     Labels=[LabelsType(
+                                         externalModel="ocrd-tool",
+                                         externalId="parameters",
+                                         Label=[LabelType(type_=name,
+                                                          value=self.parameter[name])
+                                                for name in self.parameter.keys()])]))
+                
                 page_image, page_xywh, _ = self.workspace.image_from_page(
                     page, page_id)
                 LOG.info("Binarizing on '%s' level in page '%s'", oplevel, page_id)
@@ -129,5 +135,6 @@ class TesserocrBinarize(Processor):
                                     page_id=page_id,
                                     file_grp=self.image_grp)
         # update PAGE (reference the image file):
+        features = xywh['features'] + ",binarized"
         segment.add_AlternativeImage(AlternativeImageType(
-            filename=file_path, comments="binarized"))
+            filename=file_path, comments=features))

--- a/ocrd_tesserocr/crop.py
+++ b/ocrd_tesserocr/crop.py
@@ -4,6 +4,7 @@ import os.path
 import tesserocr
 from ocrd_utils import (
     getLogger, concat_padded,
+    crop_image,
     bbox_from_points, points_from_bbox, bbox_from_xywh,
     MIMETYPE_PAGE
 )
@@ -22,7 +23,7 @@ from .config import TESSDATA_PREFIX, OCRD_TOOL
 
 TOOL = 'ocrd-tesserocr-crop'
 LOG = getLogger('processor.TesserocrCrop')
-FILEGRP_IMG = 'OCR-D-IMG-CROP'
+FALLBACK_FILEGRP_IMG = 'OCR-D-IMG-CROP'
 
 class TesserocrCrop(Processor):
 
@@ -30,6 +31,14 @@ class TesserocrCrop(Processor):
         kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         kwargs['version'] = OCRD_TOOL['version']
         super(TesserocrCrop, self).__init__(*args, **kwargs)
+        if hasattr(self, 'output_file_grp'):
+            try:
+                self.page_grp, self.image_grp = self.output_file_grp.split(',')
+            except ValueError:
+                self.page_grp = self.output_file_grp
+                self.image_grp = FALLBACK_FILEGRP_IMG
+                LOG.info("No output file group for images specified, falling back to '%s'",
+                         FALLBACK_FILEGRP_IMG)
 
     def process(self):
         """Performs page cropping with Tesseract on the workspace.
@@ -38,6 +47,12 @@ class TesserocrCrop(Processor):
         Set up Tesseract to detect text blocks on each page, and find
         the largest coordinate extent spanning all of them. Use this
         extent in defining a Border, and add that to the page.
+        
+        Moreover, crop the original image accordingly, and reference the
+        resulting image file as AlternativeImage in the Page element.
+        Add the new image file to the workspace with the fileGrp USE given
+        in the second position of the output fileGrp, or ``OCR-D-IMG-CROP``,
+        and an ID based on input file and input element.
         
         Produce new output files by serialising the resulting hierarchy.
         """
@@ -53,27 +68,47 @@ class TesserocrCrop(Processor):
                 page_id = input_file.pageId or input_file.ID
                 LOG.info("INPUT FILE %i / %s", n, page_id)
                 pcgts = page_from_file(self.workspace.download_file(input_file))
+                page = pcgts.get_Page()
+                
+                # add metadata about this operation and its runtime parameters:
                 metadata = pcgts.get_Metadata() # ensured by from_file()
                 metadata.add_MetadataItem(
                     MetadataItemType(type_="processingStep",
                                      name=self.ocrd_tool['steps'][0],
                                      value=TOOL,
-                                     # FIXME: externalRef is invalid by pagecontent.xsd, but ocrd does not reflect this
-                                     # what we want here is `externalModel="ocrd-tool" externalId="parameters"`
-                                     Labels=[LabelsType(#externalRef="parameters",
-                                                        Label=[LabelType(type_=name,
-                                                                         value=self.parameter[name])
-                                                               for name in self.parameter.keys()])]))
-                page = pcgts.get_Page()
+                                     Labels=[LabelsType(
+                                         externalModel="ocrd-tool",
+                                         externalId="parameters",
+                                         Label=[LabelType(type_=name,
+                                                          value=self.parameter[name])
+                                                for name in self.parameter.keys()])]))
+                
+                # warn of existing Border:
                 border = page.get_Border()
                 if border:
                     left, top, right, bottom = bbox_from_points(border.get_Coords().points)
                     LOG.warning('Overwriting existing Border: %i:%i,%i:%i',
                                 left, top, right, bottom)
+                
+                page_image, page_xywh, page_image_info = self.workspace.image_from_page(
+                    page, page_id,
+                    # image must not have been rotated or cropped already,
+                    # abort if no such image can be produced:
+                    feature_filter='deskewed,cropped')
+                if page_image_info.resolution != 1:
+                    dpi = page_image_info.resolution
+                    if page_image_info.resolutionUnit == 'cm':
+                        dpi = round(dpi * 2.54)
+                    tessapi.SetVariable('user_defined_dpi', str(dpi))
+                    zoom = 300 / dpi
+                else:
+                    zoom = 1
+                
+                # warn of existing segmentation:
                 regions = page.get_TextRegion()
                 if regions:
-                    min_x = image.width
-                    min_y = image.height
+                    min_x = page_image.width
+                    min_y = page_image.height
                     max_x = 0
                     max_y = 0
                     for region in regions:
@@ -84,17 +119,7 @@ class TesserocrCrop(Processor):
                         max_y = max(max_y, bottom)
                     LOG.warning('Ignoring extent from existing TextRegions: %i:%i,%i:%i',
                                 min_x, max_x, min_y, max_y)
-                
-                page_image = self.workspace.resolve_image_as_pil(page.imageFilename)
-                page_image_info = OcrdExif(page_image)
-                if page_image_info.xResolution != 1:
-                    dpi = page_image_info.xResolution
-                    if page_image_info.resolutionUnit == 'cm':
-                        dpi = round(dpi * 2.54)
-                    tessapi.SetVariable('user_defined_dpi', str(dpi))
-                    zoom = 300 / dpi
-                else:
-                    zoom = 1
+                    
                 LOG.debug("Cropping with tesseract")
                 tessapi.SetImage(page_image)
                 # PSM.SPARSE_TEXT: get as much text as possible in no particular order
@@ -155,31 +180,32 @@ class TesserocrCrop(Processor):
                     # update PAGE (annotate border):
                     page.set_Border(border)
                     # update METS (add the image file):
-                    page_image = page_image.crop(
+                    page_image = crop_image(page_image,
                         box=(min_x, min_y, max_x, max_y))
-                    file_id = input_file.ID.replace(self.input_file_grp, FILEGRP_IMG)
+                    page_xywh['features'] += ',cropped'
+                    file_id = input_file.ID.replace(self.input_file_grp, self.image_grp)
                     if file_id == input_file.ID:
-                        file_id = concat_padded(FILEGRP_IMG, n)
+                        file_id = concat_padded(self.image_grp, n)
                     file_path = self.workspace.save_image_file(page_image,
                                                 file_id,
                                                 page_id=page_id,
-                                                file_grp=FILEGRP_IMG)
+                                                file_grp=self.image_grp)
                     # update PAGE (reference the image file):
                     page.add_AlternativeImage(AlternativeImageType(
-                        filename=file_path, comments="cropped"))
+                        filename=file_path, comments=page_xywh['features']))
                 else:
                     LOG.error("Cannot find valid extent for page '%s'", page_id)
 
                 # Use input_file's basename for the new file -
                 # this way the files retain the same basenames:
-                file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
+                file_id = input_file.ID.replace(self.input_file_grp, self.page_grp)
                 if file_id == input_file.ID:
-                    file_id = concat_padded(self.output_file_grp, n)
+                    file_id = concat_padded(self.page_grp, n)
                 self.workspace.add_file(
                     ID=file_id,
-                    file_grp=self.output_file_grp,
+                    file_grp=self.page_grp,
                     pageId=input_file.pageId,
                     mimetype=MIMETYPE_PAGE,
-                    local_filename=os.path.join(self.output_file_grp,
+                    local_filename=os.path.join(self.page_grp,
                                                 file_id + '.xml'),
                     content=to_xml(pcgts))

--- a/ocrd_tesserocr/crop.py
+++ b/ocrd_tesserocr/crop.py
@@ -16,7 +16,6 @@ from ocrd_models.ocrd_page import (
     to_xml
 )
 from ocrd_models.ocrd_page_generateds import BorderType
-from ocrd_models import OcrdExif
 from ocrd import Processor
 
 from .config import TESSDATA_PREFIX, OCRD_TOOL

--- a/ocrd_tesserocr/deskew.py
+++ b/ocrd_tesserocr/deskew.py
@@ -243,7 +243,7 @@ class TesserocrDeskew(Processor):
         if layout:
             orientation, writing_direction, textline_order, deskew_angle = layout.Orientation()
             deskew_angle *= - 180 / math.pi
-            if int(deskew_angle):
+            if deskew_angle:
                 features += ',deskewed'
             LOG.info('orientation/deskewing for %s: %s / %s / %s / %.3f°', where,
                       membername(Orientation, orientation),

--- a/ocrd_tesserocr/deskew.py
+++ b/ocrd_tesserocr/deskew.py
@@ -116,7 +116,7 @@ class TesserocrDeskew(Processor):
                                           file_id)
                 else:
                     if page_xywh['angle']:
-                        log.info("About to rotate page '%s' by %.2f°",
+                        LOG.info("About to rotate page '%s' by %.2f°",
                           page_id, page_xywh['angle'])
                         page_image = page_image.rotate(page_xywh['angle'],
                                                        expand=True,

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -62,6 +62,7 @@ class TesserocrRecognize(Processor):
             for sub_model in model.split('+'):
                 if sub_model not in get_languages()[1]:
                     raise Exception("configured model " + sub_model + " is not installed")
+        
         with PyTessBaseAPI(path=TESSDATA_PREFIX, lang=model) as tessapi:
             LOG.info("Using model '%s' in %s for recognition at the %s level",
                      model, get_languages()[0], maxlevel)
@@ -116,26 +117,29 @@ class TesserocrRecognize(Processor):
                 page_id = input_file.pageId or input_file.ID
                 LOG.info("INPUT FILE %i / %s", n, page_id)
                 pcgts = page_from_file(self.workspace.download_file(input_file))
+                page = pcgts.get_Page()
+                
+                # add metadata about this operation and its runtime parameters:
                 metadata = pcgts.get_Metadata() # ensured by from_file()
                 metadata.add_MetadataItem(
                     MetadataItemType(type_="processingStep",
                                      name=self.ocrd_tool['steps'][0],
                                      value=TOOL,
-                                     # FIXME: externalRef is invalid by pagecontent.xsd, but ocrd does not reflect this
-                                     # what we want here is `externalModel="ocrd-tool" externalId="parameters"`
-                                     Labels=[LabelsType(#externalRef="parameters",
-                                                        Label=[LabelType(type_=name,
-                                                                         value=self.parameter[name])
-                                                               for name in self.parameter.keys()])]))
-                page = pcgts.get_Page()
+                                     Labels=[LabelsType(
+                                         externalModel="ocrd-tool",
+                                         externalId="parameters",
+                                         Label=[LabelType(type_=name,
+                                                          value=self.parameter[name])
+                                                for name in self.parameter.keys()])]))
                 page_image, page_xywh, page_image_info = self.workspace.image_from_page(
                     page, page_id)
-                if page_image_info.xResolution != 1:
-                    dpi = page_image_info.xResolution
+                if page_image_info.resolution != 1:
+                    dpi = page_image_info.resolution
                     if page_image_info.resolutionUnit == 'cm':
                         dpi = round(dpi * 2.54)
                     tessapi.SetVariable('user_defined_dpi', str(dpi))
                 #tessapi.SetImage(page_image)
+                
                 LOG.info("Processing page '%s'", page_id)
                 regions = page.get_TextRegion()
                 if not regions:

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -43,13 +43,13 @@ class TesserocrRecognize(Processor):
         
         Open and deserialise PAGE input files and their respective images,
         then iterate over the element hierarchy down to the requested
-        `textequiv_level`. If `overwrite_words` is enabled and any layout
+        ``textequiv_level``. If ``overwrite_words`` is enabled and any layout
         annotation below the line level already exists, then remove it
-        (regardless of `textequiv_level`).
+        (regardless of ``textequiv_level``).
         Set up Tesseract to recognise each segment's image rectangle with
-        the appropriate mode and `model`. Create new elements below the line
+        the appropriate mode and ``model``. Create new elements below the line
         level if necessary. Put text results and confidence values into new
-        TextEquiv at `textequiv_level`, and make the higher levels consistent
+        TextEquiv at ``textequiv_level``, and make the higher levels consistent
         with that (by concatenation joined by whitespace).
 
         Produce new output files by serialising the resulting hierarchy.
@@ -358,7 +358,7 @@ class TesserocrRecognize(Processor):
                 result_it.Next(RIL.SYMBOL)
 
 def page_update_higher_textequiv_levels(level, pcgts):
-    '''Update the TextEquivs of all PAGE-XML hierarchy levels above `level` for consistency.
+    '''Update the TextEquivs of all PAGE-XML hierarchy levels above ``level`` for consistency.
     
     Starting with the hierarchy level chosen for processing,
     join all first TextEquiv (by the rules governing the respective level)

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -132,7 +132,13 @@ class TesserocrRecognize(Processor):
                                                           value=self.parameter[name])
                                                 for name in self.parameter.keys()])]))
                 page_image, page_xywh, page_image_info = self.workspace.image_from_page(
-                    page, page_id)
+                    page, page_id,
+                    # the internal ImageData representation of Tesseract LSTMs
+                    # is 8 bit grayscale (input is always converted to that);
+                    # its binarization is only used for non-LSTMs and for the
+                    # layout analysis components;
+                    # therefore, using binarization degrades performance:
+                    feature_filter='binarized')
                 if page_image_info.resolution != 1:
                     dpi = page_image_info.resolution
                     if page_image_info.resolutionUnit == 'cm':
@@ -165,7 +171,13 @@ class TesserocrRecognize(Processor):
     def _process_regions(self, tessapi, regions, page_image, page_xywh):
         for region in regions:
             region_image, region_xywh = self.workspace.image_from_segment(
-                region, page_image, page_xywh)
+                region, page_image, page_xywh,
+                # the internal ImageData representation of Tesseract LSTMs
+                # is 8 bit grayscale (input is always converted to that);
+                # its binarization is only used for non-LSTMs and for the
+                # layout analysis components;
+                # therefore, using binarization degrades performance:
+                feature_filter='binarized')
             if self.parameter['textequiv_level'] == 'region':
                 tessapi.SetImage(region_image)
                 tessapi.SetPageSegMode(PSM.SINGLE_BLOCK)
@@ -191,7 +203,13 @@ class TesserocrRecognize(Processor):
             if self.parameter['overwrite_words']:
                 line.set_Word([])
             line_image, line_xywh = self.workspace.image_from_segment(
-                line, region_image, region_xywh)
+                line, region_image, region_xywh,
+                # the internal ImageData representation of Tesseract LSTMs
+                # is 8 bit grayscale (input is always converted to that);
+                # its binarization is only used for non-LSTMs and for the
+                # layout analysis components;
+                # therefore, using binarization degrades performance:
+                feature_filter='binarized')
             # todo: Tesseract works better if the line images have a 5px margin everywhere
             tessapi.SetImage(line_image)
             # RAW_LINE fails with pre-LSTM models, but sometimes better with LSTM models
@@ -203,6 +221,8 @@ class TesserocrRecognize(Processor):
                 line_conf = tessapi.MeanTextConf()/100.0 # iterator scores are arithmetic averages, too
                 if line.get_TextEquiv():
                     LOG.warning("Line '%s' already contained text results", line.id)
+                    LOG.debug("old '%s': '%s'", line.id, line.get_TextEquiv()[0].Unicode)
+                    LOG.debug("new '%s': '%s'", line.id, line_text)
                     line.set_TextEquiv([])
                 # todo: consider BlankBeforeWord, SetLineSeparator
                 line.add_TextEquiv(TextEquivType(Unicode=line_text, conf=line_conf))
@@ -268,7 +288,13 @@ class TesserocrRecognize(Processor):
     def _process_existing_words(self, tessapi, words, line_image, line_xywh):
         for word in words:
             word_image, word_xywh = self.workspace.image_from_segment(
-                word, line_image, line_xywh)
+                word, line_image, line_xywh,
+                # the internal ImageData representation of Tesseract LSTMs
+                # is 8 bit grayscale (input is always converted to that);
+                # its binarization is only used for non-LSTMs and for the
+                # layout analysis components;
+                # therefore, using binarization degrades performance:
+                feature_filter='binarized')
             tessapi.SetImage(word_image)
             tessapi.SetPageSegMode(PSM.SINGLE_WORD)
             if self.parameter['textequiv_level'] == 'word':
@@ -296,7 +322,13 @@ class TesserocrRecognize(Processor):
     def _process_existing_glyphs(self, tessapi, glyphs, word_image, word_xywh):
         for glyph in glyphs:
             glyph_image, _ = self.workspace.image_from_segment(
-                glyph, word_image, word_xywh)
+                glyph, word_image, word_xywh,
+                # the internal ImageData representation of Tesseract LSTMs
+                # is 8 bit grayscale (input is always converted to that);
+                # its binarization is only used for non-LSTMs and for the
+                # layout analysis components;
+                # therefore, using binarization degrades performance:
+                feature_filter='binarized')
             tessapi.SetImage(glyph_image)
             tessapi.SetPageSegMode(PSM.SINGLE_CHAR)
             LOG.debug("Recognizing text in glyph '%s'", glyph.id)

--- a/ocrd_tesserocr/segment_line.py
+++ b/ocrd_tesserocr/segment_line.py
@@ -36,7 +36,7 @@ class TesserocrSegmentLine(Processor):
         
         Open and deserialize PAGE input files and their respective images,
         then iterate over the element hierarchy down to the region level,
-        and remove any existing TextLine elements (unless `overwrite_lines`
+        and remove any existing TextLine elements (unless ``overwrite_lines``
         is False).
         
         Set up Tesseract to detect lines, and add each one to the region

--- a/ocrd_tesserocr/segment_line.py
+++ b/ocrd_tesserocr/segment_line.py
@@ -54,22 +54,25 @@ class TesserocrSegmentLine(Processor):
                 page_id = input_file.pageId or input_file.ID
                 LOG.info("INPUT FILE %i / %s", n, page_id)
                 pcgts = page_from_file(self.workspace.download_file(input_file))
+                page = pcgts.get_Page()
+                
+                # add metadata about this operation and its runtime parameters:
                 metadata = pcgts.get_Metadata() # ensured by from_file()
                 metadata.add_MetadataItem(
                     MetadataItemType(type_="processingStep",
                                      name=self.ocrd_tool['steps'][0],
                                      value=TOOL,
-                                     # FIXME: externalRef is invalid by pagecontent.xsd, but ocrd does not reflect this
-                                     # what we want here is `externalModel="ocrd-tool" externalId="parameters"`
-                                     Labels=[LabelsType(#externalRef="parameters",
-                                                        Label=[LabelType(type_=name,
-                                                                         value=self.parameter[name])
-                                                               for name in self.parameter.keys()])]))
-                page = pcgts.get_Page()
+                                     Labels=[LabelsType(
+                                         externalModel="ocrd-tool",
+                                         externalId="parameters",
+                                         Label=[LabelType(type_=name,
+                                                          value=self.parameter[name])
+                                                for name in self.parameter.keys()])]))
+                
                 page_image, page_xywh, page_image_info = self.workspace.image_from_page(
                     page, page_id)
-                if page_image_info.xResolution != 1:
-                    dpi = page_image_info.xResolution
+                if page_image_info.resolution != 1:
+                    dpi = page_image_info.resolution
                     if page_image_info.resolutionUnit == 'cm':
                         dpi = round(dpi * 2.54)
                     tessapi.SetVariable('user_defined_dpi', str(dpi))

--- a/ocrd_tesserocr/segment_region.py
+++ b/ocrd_tesserocr/segment_region.py
@@ -133,7 +133,7 @@ class TesserocrSegmentRegion(Processor):
                     if overwrite_regions:
                         LOG.info('overwriting existing ReadingOrder')
                         # (cannot sustain old regionrefs)
-                        page.set_ReadingOrder([])
+                        page.set_ReadingOrder(None)
                     else:
                         LOG.warning('keeping existing ReadingOrder')
                 

--- a/ocrd_tesserocr/segment_region.py
+++ b/ocrd_tesserocr/segment_region.py
@@ -59,19 +59,19 @@ class TesserocrSegmentRegion(Processor):
         
         Open and deserialize PAGE input files and their respective images,
         and remove any existing Region and ReadingOrder elements
-        (unless `overwrite_regions` is False).
+        (unless ``overwrite_regions`` is False).
         
         Set up Tesseract to detect blocks, and add each one to the page
         as a region according to BlockType at the detected coordinates.
-        If `find_tables` is True, try to detect table blocks and add them
+        If ``find_tables`` is True, try to detect table blocks and add them
         as (atomic) TableRegion.
         
-        If `crop_polygons` is True, create a cropped (and possibly deskewed)
+        If ``crop_polygons`` is True, create a cropped (and possibly deskewed)
         image (without extra binarization) for each region (which gets
         clipped to white outside its polygon outline), and reference th
         resulting image file as AlternativeImage in the region element.
         Add the new image to the workspace with the fileGrp USE given
-        in the second position of the output fileGrp, or `OCR-D-IMG-CROP`,
+        in the second position of the output fileGrp, or ``OCR-D-IMG-CROP``,
         and an ID based on input file and input element.
         
         Produce a new output file by serialising the resulting hierarchy.

--- a/ocrd_tesserocr/segment_region.py
+++ b/ocrd_tesserocr/segment_region.py
@@ -37,11 +37,7 @@ from .config import TESSDATA_PREFIX, OCRD_TOOL
 
 TOOL = 'ocrd-tesserocr-segment-region'
 LOG = getLogger('processor.TesserocrSegmentRegion')
-FILEGRP_IMG = 'OCR-D-IMG-CROP'
-
-# (will be passed as padding to both BoundingBox and GetImage)
-# (actually, Tesseract honours padding only on the left and bottom,
-#  whereas right and top are increased less)
+FALLBACK_FILEGRP_IMG = 'OCR-D-IMG-CROP'
 
 class TesserocrSegmentRegion(Processor):
 
@@ -49,6 +45,14 @@ class TesserocrSegmentRegion(Processor):
         kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         kwargs['version'] = OCRD_TOOL['version']
         super(TesserocrSegmentRegion, self).__init__(*args, **kwargs)
+        if hasattr(self, 'output_file_grp'):
+            try:
+                self.page_grp, self.image_grp = self.output_file_grp.split(',')
+            except ValueError:
+                self.page_grp = self.output_file_grp
+                self.image_grp = FALLBACK_FILEGRP_IMG
+                LOG.info("No output file group for images specified, falling back to '%s'",
+                         FALLBACK_FILEGRP_IMG)
 
     def process(self):
         """Performs (text) region segmentation with Tesseract on the workspace.
@@ -63,9 +67,12 @@ class TesserocrSegmentRegion(Processor):
         as (atomic) TableRegion.
         
         If `crop_polygons` is True, create a cropped (and possibly deskewed)
-        raw image file for each region (masked along its polygon outline),
-        and reference it as AlternativeImage in the region element and
-        as file with a fileGrp USE equal `OCR-D-IMG-CROP` in the workspace.
+        image (without extra binarization) for each region (which gets
+        clipped to white outside its polygon outline), and reference th
+        resulting image file as AlternativeImage in the region element.
+        Add the new image to the workspace with the fileGrp USE given
+        in the second position of the output fileGrp, or `OCR-D-IMG-CROP`,
+        and an ID based on input file and input element.
         
         Produce a new output file by serialising the resulting hierarchy.
         """
@@ -83,22 +90,26 @@ class TesserocrSegmentRegion(Processor):
                 # analysed as independent text/line blocks:
                 tessapi.SetVariable("textord_tabfind_find_tables", "0")
             for (n, input_file) in enumerate(self.input_files):
-                file_id = input_file.ID.replace(self.input_file_grp, FILEGRP_IMG)
+                file_id = input_file.ID.replace(self.input_file_grp, self.image_grp)
                 page_id = input_file.pageId or input_file.ID
                 LOG.info("INPUT FILE %i / %s", n, page_id)
                 pcgts = page_from_file(self.workspace.download_file(input_file))
+                page = pcgts.get_Page()
+                
+                # add metadata about this operation and its runtime parameters:
                 metadata = pcgts.get_Metadata() # ensured by from_file()
                 metadata.add_MetadataItem(
                     MetadataItemType(type_="processingStep",
                                      name=self.ocrd_tool['steps'][0],
                                      value=TOOL,
-                                     # FIXME: externalRef is invalid by pagecontent.xsd, but ocrd does not reflect this
-                                     # what we want here is `externalModel="ocrd-tool" externalId="parameters"`
-                                     Labels=[LabelsType(#externalRef="parameters",
-                                                        Label=[LabelType(type_=name,
-                                                                         value=self.parameter[name])
-                                                               for name in self.parameter.keys()])]))
-                page = pcgts.get_Page()
+                                     Labels=[LabelsType(
+                                         externalModel="ocrd-tool",
+                                         externalId="parameters",
+                                         Label=[LabelType(type_=name,
+                                                          value=self.parameter[name])
+                                                for name in self.parameter.keys()])]))
+
+                # delete or warn of existing regions:
                 if page.get_TextRegion():
                     if overwrite_regions:
                         LOG.info('removing existing TextRegions')
@@ -125,13 +136,15 @@ class TesserocrSegmentRegion(Processor):
                         page.set_ReadingOrder([])
                     else:
                         LOG.warning('keeping existing ReadingOrder')
+                
                 page_image, page_xywh, page_image_info = self.workspace.image_from_page(
                     page, page_id)
-                if page_image_info.xResolution != 1:
-                    dpi = page_image_info.xResolution
+                if page_image_info.resolution != 1:
+                    dpi = page_image_info.resolution
                     if page_image_info.resolutionUnit == 'cm':
                         dpi = round(dpi * 2.54)
                     tessapi.SetVariable('user_defined_dpi', str(dpi))
+                
                 LOG.info("Detecting regions in page '%s'", page_id)
                 tessapi.SetImage(page_image) # is already cropped to Border
                 tessapi.SetPageSegMode(PSM.AUTO) # (default)
@@ -142,15 +155,15 @@ class TesserocrSegmentRegion(Processor):
                 
                 # Use input_file's basename for the new file -
                 # this way the files retain the same basenames:
-                file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
+                file_id = input_file.ID.replace(self.input_file_grp, self.page_grp)
                 if file_id == input_file.ID:
-                    file_id = concat_padded(self.output_file_grp, n)
+                    file_id = concat_padded(self.page_grp, n)
                 self.workspace.add_file(
                     ID=file_id,
-                    file_grp=self.output_file_grp,
+                    file_grp=self.page_grp,
                     pageId=input_file.pageId,
                     mimetype=MIMETYPE_PAGE,
-                    local_filename=os.path.join(self.output_file_grp,
+                    local_filename=os.path.join(self.page_grp,
                                                 file_id + '.xml'),
                     content=to_xml(pcgts))
 
@@ -161,17 +174,20 @@ class TesserocrSegmentRegion(Processor):
         # and its BlockPolygon()
         index = 0
         while it and not it.Empty(RIL.BLOCK):
+            # (padding will be passed to both BoundingBox and GetImage)
+            # (actually, Tesseract honours padding only on the left and bottom,
+            #  whereas right and top are increased less!)
             bbox = it.BoundingBox(RIL.BLOCK, padding=self.parameter['padding'])
             points = points_from_x0y0x1y1(bbox)
-            # add offset from any Border:
+            # add offset from Border, if any:
             xywh = xywh_from_points(points)
             xywh['x'] += page_xywh['x']
             xywh['y'] += page_xywh['y']
             points = points_from_xywh(xywh)
             # sometimes these polygons are not planar, which causes
             # PIL.ImageDraw.Draw.polygon (and likely others as well)
-            # to misbehave; unfortunately, we do not have coordinate
-            # semantics in PAGE (left/right inner/outer, multi-path etc)
+            # to misbehave; however, PAGE coordinate semantics prohibit
+            # multi-path polygons!
             # (probably a bug in Tesseract itself):
             polygon = it.BlockPolygon()
             if self.parameter['crop_polygons'] and polygon and list(polygon):
@@ -216,7 +232,8 @@ class TesserocrSegmentRegion(Processor):
                               # it is a bad idea to create a TextRegion
                               # for it (better set `find_tables` False):
                               # PT.TABLE,
-                              # will always yield a 90° deskew angle below:
+                              # should actually get a 90° @orientation
+                              # (but that's ultimately for deskewing to decide):
                               PT.VERTICAL_TEXT]:
                 region = TextRegionType(id=ID, Coords=coords)
                 page.add_TextRegion(region)
@@ -259,14 +276,15 @@ class TesserocrSegmentRegion(Processor):
                 # You have been warned!
                 # get the raw image (masked by white space along the block polygon):
                 region_image, _, _ = it.GetImage(RIL.BLOCK, self.parameter['padding'], page_image)
+                page_xywh['features'] += ',cropped'
                 # update METS (add the image file):
                 file_path = self.workspace.save_image_file(region_image,
                                             file_id + '_' + ID,
                                             page_id=page_id,
-                                            file_grp=FILEGRP_IMG)
+                                            file_grp=self.image_grp)
                 # update PAGE (reference the image file):
                 region.add_AlternativeImage(AlternativeImageType(
-                    filename=file_path, comments="cropped"))
+                    filename=file_path, comments=page_xywh['features']))
             #
             # iterator increment
             #

--- a/ocrd_tesserocr/segment_word.py
+++ b/ocrd_tesserocr/segment_word.py
@@ -53,22 +53,24 @@ class TesserocrSegmentWord(Processor):
                 page_id = input_file.pageId or input_file.ID
                 LOG.info("INPUT FILE %i / %s", n, page_id)
                 pcgts = page_from_file(self.workspace.download_file(input_file))
+                page = pcgts.get_Page()
+                
+                # add metadata about this operation and its runtime parameters:
                 metadata = pcgts.get_Metadata() # ensured by from_file()
                 metadata.add_MetadataItem(
                     MetadataItemType(type_="processingStep",
                                      name=self.ocrd_tool['steps'][0],
                                      value=TOOL,
-                                     # FIXME: externalRef is invalid by pagecontent.xsd, but ocrd does not reflect this
-                                     # what we want here is `externalModel="ocrd-tool" externalId="parameters"`
-                                     Labels=[LabelsType(#externalRef="parameters",
-                                                        Label=[LabelType(type_=name,
-                                                                         value=self.parameter[name])
-                                                               for name in self.parameter.keys()])]))
-                page = pcgts.get_Page()
+                                     Labels=[LabelsType(
+                                         externalModel="ocrd-tool",
+                                         externalId="parameters",
+                                         Label=[LabelType(type_=name,
+                                                          value=self.parameter[name])
+                                                for name in self.parameter.keys()])]))
                 page_image, page_xywh, page_image_info = self.workspace.image_from_page(
                     page, page_id)
-                if page_image_info.xResolution != 1:
-                    dpi = page_image_info.xResolution
+                if page_image_info.resolution != 1:
+                    dpi = page_image_info.resolution
                     if page_image_info.resolutionUnit == 'cm':
                         dpi = round(dpi * 2.54)
                     tessapi.SetVariable('user_defined_dpi', str(dpi))

--- a/ocrd_tesserocr/segment_word.py
+++ b/ocrd_tesserocr/segment_word.py
@@ -35,7 +35,7 @@ class TesserocrSegmentWord(Processor):
         
         Open and deserialize PAGE input files and their respective images,
         then iterate over the element hierarchy down to the textline level,
-        and remove any existing Word elements (unless `overwrite_words`
+        and remove any existing Word elements (unless ``overwrite_words``
         is False).
         
         Set up Tesseract to detect words, and add each one to the line

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ocrd >= 1.0.0b17
 click
-tesserocr==2.4.1
+tesserocr>=2.4.1

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='ocrd_tesserocr',
-    version='0.4.0',
+    version='0.4.1',
     description='Tesserocr bindings',
     long_description=codecs.open('README.rst', encoding='utf-8').read(),
     author='Konstantin Baierer, Kay-Michael Würzner, Robert Sachunsky',


### PR DESCRIPTION
- all: use second output position as fileGrp USE to produce
  AlternativeImage
- all: rid of MetadataItem/Labels-related FIXME:
  with the updated PAGE model, we can now use
  @externalModel and @externalId
- all: use OcrdExif.resolution instead of xResolution
- all: create images with monotonically growing @comments
  (features)
- crop: use ocrd_utils.crop_image instead of PIL.Image.crop
- crop: fix bug when trying to access page_image if there
  are already region coordinates that we are ignoring
- crop: filter images already deskewed and cropped!
  (we must crop ourselves, and deskewing can not happen
   until afterwards)
- deskew: fix bugs in configuration-dependent corner cases
  related to whether deskewing has already been applied
  (on the page or region level):
  - for the page image, never use images already rotated
    (both for page level and region level processing,
     but for the region level, do rotate images ad hoc
     if @orientation is present on the page level)
  - for the region image, never use images already rotated
    (except for our own page-level rotation)
- segment-region: forgot to add feature "cropped" when
  producing cropped images