### PR TITLE
fix requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ocrd >= 1.0.0b17
+ocrd >= 1.0.0
 click
 tesserocr>=2.4.1


### PR DESCRIPTION
do not refer to prereleases of `ocrd` any longer, as this drags in `2.0` re-releases now