### PR TITLE
Update rules in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,9 @@ COPY requirements.txt .
 COPY requirements_test.txt .
 COPY ocrd_tesserocr ./ocrd_tesserocr
 COPY Makefile .
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends software-properties-common && \
-    add-apt-repository -y ppa:alex-p/tesseract-ocr && \
+RUN make deps-ubuntu && \
     apt-get install -y --no-install-recommends \
-    g++ libtesseract-dev make \
-    tesseract-ocr \
+    g++ make \
     tesseract-ocr-script-frak \
     tesseract-ocr-deu \
     && make deps install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY ocrd_tesserocr ./ocrd_tesserocr
 COPY Makefile .
 RUN make deps-ubuntu && \
     apt-get install -y --no-install-recommends \
-    g++ make \
+    g++ \
     tesseract-ocr-script-frak \
     tesseract-ocr-deu \
     && make deps install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,15 +11,13 @@ COPY requirements_test.txt .
 COPY ocrd_tesserocr ./ocrd_tesserocr
 COPY Makefile .
 RUN apt-get update && \
-    apt-get install -y software-properties-common && \
-    add-apt-repository ppa:alex-p/tesseract-ocr && \
-    apt-get update && \
-    apt-get -y install --no-install-recommends \
-    libtesseract-dev \
+    apt-get install -y --no-install-recommends software-properties-common && \
+    add-apt-repository -y ppa:alex-p/tesseract-ocr && \
+    apt-get install -y --no-install-recommends \
+    g++ libtesseract-dev make \
     tesseract-ocr \
     tesseract-ocr-script-frak \
     tesseract-ocr-deu \
-    build-essential \
     && make deps install \
     && rm -rf /build-ocrd \
-    && apt-get -y remove --auto-remove build-essential
+    && apt-get -y remove --auto-remove g++ libtesseract-dev make


### PR DESCRIPTION
- Only install required packages for software-properties-common
- Add missing option `-y` for add-apt-repository
- Remove unneeded update after add-apt-repository
- Replace build-essential by the required packages g++ and make
- Remove libtesseract-dev when it is no longer needed

Signed-off-by: Stefan Weil <sw@weilnetz.de>