### PR TITLE
improve segmentation

### DIFF
--- a/ocrd_tesserocr/cli.py
+++ b/ocrd_tesserocr/cli.py
@@ -3,6 +3,7 @@ import click
 from ocrd.decorators import ocrd_cli_options, ocrd_cli_wrap_processor
 from ocrd_tesserocr.recognize import TesserocrRecognize
 from ocrd_tesserocr.segment_region import TesserocrSegmentRegion
+from ocrd_tesserocr.segment_table import TesserocrSegmentTable
 from ocrd_tesserocr.segment_line import TesserocrSegmentLine
 from ocrd_tesserocr.segment_word import TesserocrSegmentWord
 from ocrd_tesserocr.crop import TesserocrCrop
@@ -13,6 +14,11 @@ from ocrd_tesserocr.binarize import TesserocrBinarize
 @ocrd_cli_options
 def ocrd_tesserocr_segment_region(*args, **kwargs):
     return ocrd_cli_wrap_processor(TesserocrSegmentRegion, *args, **kwargs)
+
+@click.command()
+@ocrd_cli_options
+def ocrd_tesserocr_segment_table(*args, **kwargs):
+    return ocrd_cli_wrap_processor(TesserocrSegmentTable, *args, **kwargs)
 
 @click.command()
 @ocrd_cli_options

--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -33,7 +33,7 @@
     "ocrd-tesserocr-recognize": {
       "executable": "ocrd-tesserocr-recognize",
       "categories": ["Text recognition and optimization"],
-      "description": "Recognize text lines with Tesseract (using annotated derived images, or masking and cropping images from coordinate polygons)",
+      "description": "Recognize text in lines with Tesseract (using annotated derived images, or masking and cropping images from coordinate polygons)",
       "input_file_grp": [
         "OCR-D-SEG-BLOCK",
         "OCR-D-SEG-LINE",
@@ -70,7 +70,7 @@
      "ocrd-tesserocr-segment-region": {
       "executable": "ocrd-tesserocr-segment-region",
       "categories": ["Layout analysis"],
-      "description": "Segment regions into lines with Tesseract",
+      "description": "Segment page into regions with Tesseract",
       "input_file_grp": [
         "OCR-D-IMG",
         "OCR-D-SEG-PAGE",
@@ -127,7 +127,7 @@
      "ocrd-tesserocr-segment-line": {
       "executable": "ocrd-tesserocr-segment-line",
       "categories": ["Layout analysis"],
-      "description": "Segment page into regions with Tesseract",
+      "description": "Segment regions into lines with Tesseract",
       "input_file_grp": [
         "OCR-D-SEG-BLOCK",
         "OCR-D-GT-SEG-BLOCK"

--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -33,7 +33,7 @@
     "ocrd-tesserocr-recognize": {
       "executable": "ocrd-tesserocr-recognize",
       "categories": ["Text recognition and optimization"],
-      "description": "Recognize text in lines with tesseract",
+      "description": "Recognize text lines with Tesseract (using annotated derived images, or masking and cropping images from coordinate polygons)",
       "input_file_grp": [
         "OCR-D-SEG-BLOCK",
         "OCR-D-SEG-LINE",
@@ -48,13 +48,18 @@
         "textequiv_level": {
           "type": "string",
           "enum": ["region", "line", "word", "glyph"],
-          "default": "line",
-          "description": "PAGE XML hierarchy level to add the TextEquiv results to (requires existing layout annotation up to one level above that)"
+          "default": "word",
+          "description": "Lowest PAGE XML hierarchy level to add the TextEquiv results to; when below `region`, implicitly adds segmentation below the line level, but requires existing line segmentation"
         },
         "overwrite_words": {
           "type": "boolean",
           "default": false,
-          "description": "remove existing layout and text annotation below the TextLine level (regardless of textequiv_level)"
+          "description": "Remove existing layout and text annotation below the TextLine level (regardless of textequiv_level)."
+        },
+        "raw_lines": {
+          "type": "boolean",
+          "default": true,
+          "description": "Do not attempt additional segmentation (baseline+xheight+ascenders/descenders prediction) when using line images (i.e. when textequiv_level<region). Disable when line segments/images likely contain components of more than 1 line."
         },
         "model": {
           "type": "string",
@@ -65,7 +70,7 @@
      "ocrd-tesserocr-segment-region": {
       "executable": "ocrd-tesserocr-segment-region",
       "categories": ["Layout analysis"],
-      "description": "Segment regions into lines with tesseract",
+      "description": "Segment regions into lines with Tesseract",
       "input_file_grp": [
         "OCR-D-IMG",
         "OCR-D-SEG-PAGE",
@@ -102,7 +107,7 @@
     "ocrd-tesserocr-segment-line": {
       "executable": "ocrd-tesserocr-segment-line",
       "categories": ["Layout analysis"],
-      "description": "Segment page into regions with tesseract",
+      "description": "Segment page into regions with Tesseract",
       "input_file_grp": [
         "OCR-D-SEG-BLOCK",
         "OCR-D-GT-SEG-BLOCK"
@@ -122,7 +127,7 @@
     "ocrd-tesserocr-segment-word": {
       "executable": "ocrd-tesserocr-segment-word",
       "categories": ["Layout analysis"],
-      "description": "Segment lines into words with tesseract",
+      "description": "Segment lines into words with Tesseract",
       "input_file_grp": [
         "OCR-D-SEG-LINE",
         "OCR-D-GT-SEG-LINE"

--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -104,7 +104,27 @@
         }
       }
     },
-    "ocrd-tesserocr-segment-line": {
+     "ocrd-tesserocr-segment-table": {
+      "executable": "ocrd-tesserocr-segment-table",
+      "categories": ["Layout analysis"],
+      "description": "Segment table regions into cell text regions with Tesseract",
+      "input_file_grp": [
+        "OCR-D-SEG-BLOCK",
+        "OCR-D-GT-SEG-BLOCK"
+      ],
+      "output_file_grp": [
+        "OCR-D-SEG-BLOCK"
+      ],
+      "steps": ["layout/segmentation/region"],
+      "parameters": {
+        "overwrite_regions": {
+          "type": "boolean",
+          "default": true,
+          "description": "remove existing layout and text annotation below the region level"
+        }
+      }
+     },
+     "ocrd-tesserocr-segment-line": {
       "executable": "ocrd-tesserocr-segment-line",
       "categories": ["Layout analysis"],
       "description": "Segment page into regions with Tesseract",

--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -58,8 +58,8 @@
         },
         "raw_lines": {
           "type": "boolean",
-          "default": true,
-          "description": "Do not attempt additional segmentation (baseline+xheight+ascenders/descenders prediction) when using line images (i.e. when textequiv_level<region). Disable when line segments/images likely contain components of more than 1 line."
+          "default": false,
+          "description": "Do not attempt additional segmentation (baseline+xheight+ascenders/descenders prediction) when using line images (i.e. when textequiv_level<region). Can increase accuracy for certain workflows. Disable when line segments/images may contain components of more than 1 line, or larger gaps/white-spaces."
         },
         "model": {
           "type": "string",

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -194,8 +194,10 @@ class TesserocrRecognize(Processor):
                 line, region_image, region_xywh)
             # todo: Tesseract works better if the line images have a 5px margin everywhere
             tessapi.SetImage(line_image)
-            # RAW_LINE fails with pre-LSTM models, but sometimes better with LSTM models
-            tessapi.SetPageSegMode(PSM.SINGLE_LINE)
+            if self.parameter['raw_lines']:
+                tessapi.SetPageSegMode(PSM.RAW_LINE)
+            else:
+                tessapi.SetPageSegMode(PSM.SINGLE_LINE)
             #if line.get_primaryScript() not in tessapi.GetLoadedLanguages()...
             LOG.debug("Recognizing text in line '%s'", line.id)
             if self.parameter['textequiv_level'] == 'line':

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import os.path
+import itertools
 
 from tesserocr import (
     RIL, PSM,
@@ -141,7 +142,9 @@ class TesserocrRecognize(Processor):
                 #tessapi.SetImage(page_image)
                 
                 LOG.info("Processing page '%s'", page_id)
-                regions = page.get_TextRegion()
+                regions = itertools.chain.from_iterable(
+                    [page.get_TextRegion()] +
+                    [subregion.get_TextRegion() for subregion in page.get_TableRegion()])
                 if not regions:
                     LOG.warning("Page '%s' contains no text regions", page_id)
                 else:

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -369,9 +369,11 @@ def page_update_higher_textequiv_levels(level, pcgts):
     join all first TextEquiv (by the rules governing the respective level)
     into TextEquiv of the next higher level, replacing them.
     '''
-    regions = pcgts.get_Page().get_TextRegion()
+    page = pcgts.get_Page()
     if level != 'region':
-        for region in regions:
+        for region in itertools.chain.from_iterable(
+                [page.get_TextRegion()] +
+                [subregion.get_TextRegion() for subregion in page.get_TableRegion()]):
             lines = region.get_TextLine()
             if level != 'line':
                 for line in lines:

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -384,24 +384,26 @@ class TesserocrRecognize(Processor):
                 result_it.Next(RIL.SYMBOL)
 
 def page_element_unicode0(element):
+    """Get Unicode string of the first text result."""
     if element.get_TextEquiv():
         return element.get_TextEquiv()[0].Unicode
     else:
         return ''
 
 def page_element_conf0(element):
+    """Get confidence (as float value) of the first text result."""
     if element.get_TextEquiv():
         # generateDS does not convert simpleType for attributes (yet?)
         return float(element.get_TextEquiv()[0].conf or "1.0")
     return 1.0
 
 def page_get_reading_order(ro, rogroup):
-    '''Add all elements from the given reading order group to the given dictionary.
+    """Add all elements from the given reading order group to the given dictionary.
     
     Given a dict ``ro`` from layout element IDs to ReadingOrder element objects,
     and an object ``rogroup`` with additional ReadingOrder element objects,
     add all references to the dict, traversing the group recursively.
-    '''
+    """
     if isinstance(rogroup, (OrderedGroupType, OrderedGroupIndexedType)):
         regionrefs = (rogroup.get_RegionRefIndexed() +
                       rogroup.get_OrderedGroupIndexed() +
@@ -416,7 +418,7 @@ def page_get_reading_order(ro, rogroup):
             page_get_reading_order(ro, elem)
         
 def page_update_higher_textequiv_levels(level, pcgts):
-    '''Update the TextEquivs of all PAGE-XML hierarchy levels above ``level`` for consistency.
+    """Update the TextEquivs of all PAGE-XML hierarchy levels above ``level`` for consistency.
     
     Starting with the hierarchy level chosen for processing,
     join all first TextEquiv.Unicode (by the rules governing the respective level)
@@ -434,7 +436,7 @@ def page_update_higher_textequiv_levels(level, pcgts):
     Where no direction/order can be found, use XML ordering.
     
     Follow regions recursively, but make sure to traverse them in a depth-first strategy.
-    '''
+    """
     page = pcgts.get_Page()
     relations = page.get_Relations() # get RelationsType
     if relations:

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -21,6 +21,19 @@ from ocrd_models.ocrd_page import (
     MetadataItemType,
     TextEquivType, TextStyleType,
     to_xml)
+from ocrd_models.ocrd_page_generateds import (
+    TableRegionType,
+    TextTypeSimpleType,
+    ReadingDirectionSimpleType,
+    TextLineOrderSimpleType,
+    RegionRefType,
+    RegionRefIndexedType,
+    OrderedGroupType,
+    OrderedGroupIndexedType,
+    UnorderedGroupType,
+    UnorderedGroupIndexedType,
+    ReadingOrderType
+)
 from ocrd_modelfactory import page_from_file
 from ocrd import Processor
 
@@ -44,15 +57,23 @@ class TesserocrRecognize(Processor):
         
         Open and deserialise PAGE input files and their respective images,
         then iterate over the element hierarchy down to the requested
-        ``textequiv_level``. If ``overwrite_words`` is enabled and any layout
-        annotation below the line level already exists, then remove it
-        (regardless of ``textequiv_level``).
-        Set up Tesseract to recognise each segment's image rectangle with
-        the appropriate mode and ``model``. Create new elements below the line
-        level if necessary. Put text results and confidence values into new
-        TextEquiv at ``textequiv_level``, and make the higher levels consistent
-        with that (by concatenation joined by whitespace).
-
+        ``textequiv_level`` if it exists and ``overwrite_words`` is disabled,
+        or to the line level otherwise. In the latter case,
+        (remove any existing segmentation below the line level, and)
+        create new segmentation below the line level if necessary.
+        
+        Set up Tesseract to recognise each segment's image (either from
+        AlternativeImage or cropping the bounding box rectangle and masking
+        it from the polygon outline) with the appropriate mode and ``model``.
+        
+        Put text and confidence results into the TextEquiv at ``textequiv_level``,
+        removing any existing TextEquiv.
+        
+        Finally, make the higher levels consistent with these results by concatenation,
+        ordered as appropriate for its readingDirection, textLineOrder, and ReadingOrder,
+        and joined by whitespace, as appropriate for the respective level and Relation/join
+        status.
+        
         Produce new output files by serialising the resulting hierarchy.
         """
         LOG.debug("TESSDATA: %s, installed tesseract models: %s", *get_languages())
@@ -362,37 +383,147 @@ class TesserocrRecognize(Processor):
                 glyph_no += 1
                 result_it.Next(RIL.SYMBOL)
 
+def page_element_unicode0(element):
+    if element.get_TextEquiv():
+        return element.get_TextEquiv()[0].Unicode
+    else:
+        return ''
+
+def page_element_conf0(element):
+    if element.get_TextEquiv():
+        # generateDS does not convert simpleType for attributes (yet?)
+        return float(element.get_TextEquiv()[0].conf or "1.0")
+    return 1.0
+
+def page_get_reading_order(ro, rogroup):
+    '''Add all elements from the given reading order group to the given dictionary.
+    
+    Given a dict ``ro`` from layout element IDs to ReadingOrder element objects,
+    and an object ``rogroup`` with additional ReadingOrder element objects,
+    add all references to the dict, traversing the group recursively.
+    '''
+    if isinstance(rogroup, (OrderedGroupType, OrderedGroupIndexedType)):
+        regionrefs = (rogroup.get_RegionRefIndexed() +
+                      rogroup.get_OrderedGroupIndexed() +
+                      rogroup.get_UnorderedGroupIndexed())
+    if isinstance(rogroup, (UnorderedGroupType, UnorderedGroupIndexedType)):
+        regionrefs = (rogroup.get_RegionRef() +
+                      rogroup.get_OrderedGroup() +
+                      rogroup.get_UnorderedGroup())
+    for elem in regionrefs:
+        ro[elem.get_regionRef()] = elem
+        if not isinstance(elem, (RegionRefType, RegionRefIndexedType)):
+            page_get_reading_order(ro, elem)
+        
 def page_update_higher_textequiv_levels(level, pcgts):
     '''Update the TextEquivs of all PAGE-XML hierarchy levels above ``level`` for consistency.
     
     Starting with the hierarchy level chosen for processing,
-    join all first TextEquiv (by the rules governing the respective level)
-    into TextEquiv of the next higher level, replacing them.
+    join all first TextEquiv.Unicode (by the rules governing the respective level)
+    into TextEquiv.Unicode of the next higher level, replacing them.
+    
+    When two successive elements appear in a ``Relation`` of type ``join``,
+    then join them directly (without their respective white space).
+    
+    Likewise, average all first TextEquiv.conf into TextEquiv.conf of the next higher level.
+    
+    In the process, traverse the words and lines in their respective ``readingDirection``,
+    the (text) regions which contain lines in their respective ``textLineOrder``, and
+    the (text) regions which contain text regions in their ``ReadingOrder``
+    (if they appear there as an ``OrderedGroup``).
+    Where no direction/order can be found, use XML ordering.
+    
+    Follow regions recursively, but make sure to traverse them in a depth-first strategy.
     '''
     page = pcgts.get_Page()
+    relations = page.get_Relations() # get RelationsType
+    if relations:
+        relations = relations.get_Relation() # get list of RelationType
+    else:
+        relations = []
+    joins = list() # 
+    for relation in relations:
+        if relation.get_type() == 'join': # ignore 'link' type here
+            joins.append((relation.get_SourceRegionRef().get_regionRef(),
+                          relation.get_TargetRegionRef().get_regionRef()))
+    reading_order = dict()
+    ro = page.get_ReadingOrder()
+    if ro:
+        page_get_reading_order(reading_order, ro.get_OrderedGroup() or ro.get_UnorderedGroup())
     if level != 'region':
         for region in itertools.chain.from_iterable(
-                [page.get_TextRegion()] +
-                [subregion.get_TextRegion() for subregion in page.get_TableRegion()]):
-            lines = region.get_TextLine()
-            if level != 'line':
-                for line in lines:
-                    words = line.get_Word()
-                    if level != 'word':
-                        for word in words:
-                            glyphs = word.get_Glyph()
-                            word_unicode = u''.join(glyph.get_TextEquiv()[0].Unicode
-                                                    if glyph.get_TextEquiv()
-                                                    else u'' for glyph in glyphs)
-                            word.set_TextEquiv(
-                                [TextEquivType(Unicode=word_unicode)]) # remove old
-                    line_unicode = u' '.join(word.get_TextEquiv()[0].Unicode
-                                             if word.get_TextEquiv()
-                                             else u'' for word in words)
-                    line.set_TextEquiv(
-                        [TextEquivType(Unicode=line_unicode)]) # remove old
-            region_unicode = u'\n'.join(line.get_TextEquiv()[0].Unicode
-                                        if line.get_TextEquiv()
-                                        else u'' for line in lines)
-            region.set_TextEquiv(
-                [TextEquivType(Unicode=region_unicode)]) # remove old
+                # order is important here, because regions can be recursive,
+                # and we want to concatenate by depth first;
+                # typical recursion structures would be:
+                #  - TextRegion/@type=paragraph inside TextRegion
+                #  - TextRegion/@type=drop-capital followed by TextRegion/@type=paragraph inside TextRegion
+                #  - any region (including TableRegion or TextRegion) inside a TextRegion/@type=footnote
+                #  - TextRegion inside TableRegion
+                [subregion.get_TextRegion() for subregion in page.get_TextRegion()] +
+                [subregion.get_TextRegion() for subregion in page.get_TableRegion()] +
+                [page.get_TextRegion()]):
+            subregions = region.get_TextRegion()
+            if subregions: # already visited in earlier iterations
+                # do we have a reading order for these?
+                # TODO: what if at least some of the subregions are in reading_order?
+                if (all(subregion.id in reading_order for subregion in subregions) and
+                    isinstance(reading_order[subregions[0].id], # all have .index?
+                               (OrderedGroupType, OrderedGroupIndexedType))):
+                    subregions = sorted(subregions, key=lambda subregion:
+                                        reading_order[subregion.id].index)
+                region_unicode = page_element_unicode0(subregions[0])
+                for subregion, next_subregion in zip(subregions, subregions[1:]):
+                    if not (subregion.id, next_subregion.id) in joins:
+                        region_unicode += '\n' # or '\f'?
+                    region_unicode += page_element_unicode0(next_subregion)
+                region_conf = sum(page_element_conf0(subregion) for subregion in subregions)
+                region_conf /= len(subregions)
+            else: # TODO: what if a TextRegion has both TextLine and TextRegion children?
+                lines = region.get_TextLine()
+                if (region.get_textLineOrder() or
+                    page.get_textLineOrder() ==
+                    TextLineOrderSimpleType.BOTTOMTOTOP):
+                    lines = reversed(lines)
+                if level != 'line':
+                    for line in lines:
+                        words = line.get_Word()
+                        if (line.get_readingDirection() or
+                            region.get_readingDirection() or
+                            page.get_readingDirection() ==
+                            ReadingDirectionSimpleType.RIGHTTOLEFT):
+                            words = reversed(words)
+                        if level != 'word':
+                            for word in words:
+                                glyphs = word.get_Glyph()
+                                if (word.get_readingDirection() or
+                                    line.get_readingDirection() or
+                                    region.get_readingDirection() or
+                                    page.get_readingDirection() ==
+                                    ReadingDirectionSimpleType.RIGHTTOLEFT):
+                                    glyphs = reversed(glyphs)
+                                word_unicode = ''.join(page_element_unicode0(glyph) for glyph in glyphs)
+                                word_conf = sum(page_element_conf0(glyph) for glyph in glyphs)
+                                if glyphs:
+                                    word_conf /= len(glyphs)
+                                word.set_TextEquiv( # replace old, if any
+                                    [TextEquivType(Unicode=word_unicode, conf=word_conf)])
+                        line_unicode = ' '.join(page_element_unicode0(word) for word in words)
+                        line_conf = sum(page_element_conf0(word) for word in words)
+                        if words:
+                            line_conf /= len(words)
+                        line.set_TextEquiv( # replace old, if any
+                            [TextEquivType(Unicode=line_unicode, conf=line_conf)])
+                region_unicode = ''
+                region_conf = 0
+                if lines:
+                    region_unicode = page_element_unicode0(lines[0])
+                    for line, next_line in zip(lines, lines[1:]):
+                        words = line.get_Word()
+                        next_words = next_line.get_Word()
+                        if not(words and next_words and (words[-1].id, next_words[0].id) in joins):
+                            region_unicode += '\n'
+                        region_unicode += page_element_unicode0(next_line)
+                    region_conf = sum(page_element_conf0(line) for line in lines)
+                    region_conf /= len(lines)
+            region.set_TextEquiv( # replace old, if any
+                [TextEquivType(Unicode=region_unicode, conf=region_conf)])

--- a/ocrd_tesserocr/segment_line.py
+++ b/ocrd_tesserocr/segment_line.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import itertools
 import os.path
 from tesserocr import PyTessBaseAPI, RIL, PSM
 
@@ -37,7 +38,7 @@ class TesserocrSegmentLine(Processor):
         """Performs (text) line segmentation with Tesseract on the workspace.
         
         Open and deserialize PAGE input files and their respective images,
-        then iterate over the element hierarchy down to the region level,
+        then iterate over the element hierarchy down to the (text) region level,
         and remove any existing TextLine elements (unless ``overwrite_lines``
         is False).
         
@@ -79,7 +80,9 @@ class TesserocrSegmentLine(Processor):
                         dpi = round(dpi * 2.54)
                     tessapi.SetVariable('user_defined_dpi', str(dpi))
                 
-                for region in page.get_TextRegion():
+                for region in itertools.chain.from_iterable(
+                        [page.get_TextRegion()] +
+                        [subregion.get_TextRegion() for subregion in page.get_TableRegion()]):
                     if region.get_TextLine():
                         if overwrite_lines:
                             LOG.info('removing existing TextLines in region "%s"', region.id)

--- a/ocrd_tesserocr/segment_line.py
+++ b/ocrd_tesserocr/segment_line.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import itertools
 import os.path
+from shapely.geometry import Polygon, LinearRing
 from tesserocr import PyTessBaseAPI, RIL, PSM
 
 from ocrd import Processor
@@ -10,6 +11,7 @@ from ocrd_utils import (
     polygon_from_xywh,
     points_from_polygon,
     coordinates_for_segment,
+    coordinates_of_segment,
     MIMETYPE_PAGE
 )
 from ocrd_modelfactory import page_from_file
@@ -92,10 +94,17 @@ class TesserocrSegmentLine(Processor):
                     LOG.debug("Detecting lines in region '%s'", region.id)
                     region_image, region_coords = self.workspace.image_from_segment(
                         region, page_image, page_coords)
+                    region_polygon = coordinates_of_segment(region, region_image, region_coords)
+                    region_poly = Polygon(region_polygon)
                     tessapi.SetImage(region_image)
                     for line_no, component in enumerate(tessapi.GetComponentImages(RIL.TEXTLINE, True, raw_image=True)):
                         line_id = '%s_line%04d' % (region.id, line_no)
                         line_polygon = polygon_from_xywh(component[1])
+                        line_poly = Polygon(line_polygon)
+                        if not line_poly.within(region_poly):
+                            # this could happen due to rotation
+                            line_poly = line_poly.intersection(region_poly).convex_hull
+                            line_polygon = line_poly.exterior.coords
                         line_polygon = coordinates_for_segment(line_polygon, region_image, region_coords)
                         line_points = points_from_polygon(line_polygon)
                         region.add_TextLine(TextLineType(

--- a/ocrd_tesserocr/segment_region.py
+++ b/ocrd_tesserocr/segment_region.py
@@ -29,7 +29,10 @@ from ocrd_models.ocrd_page import (
     SeparatorRegionType,
     NoiseRegionType,
     to_xml)
-from ocrd_models.ocrd_page_generateds import TableRegionType
+from ocrd_models.ocrd_page_generateds import (
+    TableRegionType,
+    TextTypeSimpleType
+)
 from ocrd import Processor
 
 from .config import TESSDATA_PREFIX, OCRD_TOOL
@@ -230,9 +233,16 @@ class TesserocrSegmentRegion(Processor):
                               # will also get a 90° @orientation
                               # (but that can be overriden by deskewing):
                               PT.VERTICAL_TEXT]:
-                region = TextRegionType(id=ID, Coords=coords)
+                region = TextRegionType(id=ID, Coords=coords,
+                                        type=TextTypeSimpleType.PARAGRAPH)
                 if block_type == PT.VERTICAL_TEXT:
                     region.set_orientation(90.0)
+                elif block_type == PT.HEADING_TEXT:
+                    region.set_type(TextTypeSimpleType.HEADING)
+                elif block_type == PT.PULLOUT_TEXT:
+                    region.set_type(TextTypeSimpleType.FLOATING)
+                elif block_type == PT.CAPTION_TEXT:
+                    region.set_type(TextTypeSimpleType.CAPTION)
                 page.add_TextRegion(region)
             elif block_type in [PT.FLOWING_IMAGE,
                                 PT.HEADING_IMAGE,

--- a/ocrd_tesserocr/segment_region.py
+++ b/ocrd_tesserocr/segment_region.py
@@ -221,10 +221,12 @@ class TesserocrSegmentRegion(Processor):
                               # it is a bad idea to create a TextRegion
                               # for it (better set `find_tables` False):
                               # PT.TABLE,
-                              # should actually get a 90° @orientation
-                              # (but that's ultimately for deskewing to decide):
+                              # will also get a 90° @orientation
+                              # (but that can be overriden by deskewing):
                               PT.VERTICAL_TEXT]:
                 region = TextRegionType(id=ID, Coords=coords)
+                if block_type == PT.VERTICAL_TEXT:
+                    region.set_orientation(90.0)
                 page.add_TextRegion(region)
             elif block_type in [PT.FLOWING_IMAGE,
                                 PT.HEADING_IMAGE,

--- a/ocrd_tesserocr/segment_region.py
+++ b/ocrd_tesserocr/segment_region.py
@@ -96,25 +96,36 @@ class TesserocrSegmentRegion(Processor):
                                                 for name in self.parameter.keys()])]))
 
                 # delete or warn of existing regions:
-                if page.get_TextRegion():
+                if (page.get_AdvertRegion() or
+                    page.get_ChartRegion() or
+                    page.get_ChemRegion() or
+                    page.get_GraphicRegion() or
+                    page.get_ImageRegion() or
+                    page.get_LineDrawingRegion() or
+                    page.get_MathsRegion() or
+                    page.get_MusicRegion() or
+                    page.get_NoiseRegion() or
+                    page.get_SeparatorRegion() or
+                    page.get_TableRegion() or
+                    page.get_TextRegion() or
+                    page.get_UnknownRegion()):
                     if overwrite_regions:
                         LOG.info('removing existing TextRegions')
                         page.set_TextRegion([])
+                        page.set_AdvertRegion([])
+                        page.set_ChartRegion([])
+                        page.set_ChemRegion([])
+                        page.set_GraphicRegion([])
+                        page.set_ImageRegion([])
+                        page.set_LineDrawingRegion([])
+                        page.set_MathsRegion([])
+                        page.set_MusicRegion([])
+                        page.set_NoiseRegion([])
+                        page.set_SeparatorRegion([])
+                        page.set_TableRegion([])
+                        page.set_UnknownRegion([])
                     else:
                         LOG.warning('keeping existing TextRegions')
-                # TODO: also make non-text regions protected?
-                page.set_AdvertRegion([])
-                page.set_ChartRegion([])
-                page.set_ChemRegion([])
-                page.set_GraphicRegion([])
-                page.set_ImageRegion([])
-                page.set_LineDrawingRegion([])
-                page.set_MathsRegion([])
-                page.set_MusicRegion([])
-                page.set_NoiseRegion([])
-                page.set_SeparatorRegion([])
-                page.set_TableRegion([])
-                page.set_UnknownRegion([])
                 if page.get_ReadingOrder():
                     if overwrite_regions:
                         LOG.info('overwriting existing ReadingOrder')

--- a/ocrd_tesserocr/segment_region.py
+++ b/ocrd_tesserocr/segment_region.py
@@ -48,7 +48,7 @@ class TesserocrSegmentRegion(Processor):
         super(TesserocrSegmentRegion, self).__init__(*args, **kwargs)
 
     def process(self):
-        """Performs (text) region segmentation with Tesseract on the workspace.
+        """Performs region segmentation with Tesseract on the workspace.
         
         Open and deserialize PAGE input files and their respective images,
         and remove any existing Region and ReadingOrder elements
@@ -74,7 +74,9 @@ class TesserocrSegmentRegion(Processor):
                 tessapi.SetVariable("textord_tabfind_find_tables", "1") # (default)
                 # this should yield additional blocks within the table blocks
                 # from the page iterator, but does not in fact (yet?):
-                tessapi.SetVariable("textord_tablefind_recognize_tables", "1")
+                # (and it can run into assertion errors when the table structure
+                #  does not meet certain homogenity expectations)
+                #tessapi.SetVariable("textord_tablefind_recognize_tables", "1")
             else:
                 # disable table detection here, so tables will be
                 # analysed as independent text/line blocks:

--- a/ocrd_tesserocr/segment_table.py
+++ b/ocrd_tesserocr/segment_table.py
@@ -98,7 +98,7 @@ class TesserocrSegmentTable(Processor):
                         dpi = round(dpi * 2.54)
                     LOG.info("setting user defined DPI %d from metadata", dpi)
                     tessapi.SetVariable('user_defined_dpi', str(dpi))
-                tessapi.SetVariable('textord_occupancy_threshold', '0.1')
+
                 #
                 # prepare dict of reading order
                 reading_order = dict()
@@ -121,8 +121,7 @@ class TesserocrSegmentTable(Processor):
                     for elem in regionrefs:
                         reading_order[elem.get_regionRef()] = elem
                         if not isinstance(elem, (RegionRefType, RegionRefIndexedType)):
-                            # recursive
-                            #_plausibilize_group(regions, elem, mark_for_deletion)
+                            # FIXME: recursive
                             pass
                 #
                 # dive into regions

--- a/ocrd_tesserocr/segment_table.py
+++ b/ocrd_tesserocr/segment_table.py
@@ -1,0 +1,246 @@
+from __future__ import absolute_import
+
+import os.path
+from tesserocr import (
+    PyTessBaseAPI,
+    PSM, RIL, PT
+)
+
+from ocrd_utils import (
+    getLogger,
+    concat_padded,
+    coordinates_for_segment,
+    polygon_from_x0y0x1y1,
+    points_from_polygon,
+    MIMETYPE_PAGE,
+    membername
+)
+from ocrd_modelfactory import page_from_file
+from ocrd_models.ocrd_page import (
+    MetadataItemType,
+    LabelsType, LabelType,
+    CoordsType,
+    TextRegionType,
+    to_xml)
+from ocrd_models.ocrd_page_generateds import (
+    TableRegionType,
+    TextTypeSimpleType,
+    RegionRefType,
+    RegionRefIndexedType,
+    OrderedGroupType,
+    OrderedGroupIndexedType,
+    UnorderedGroupType,
+    UnorderedGroupIndexedType,
+    ReadingOrderType
+)
+from ocrd import Processor
+
+from .config import TESSDATA_PREFIX, OCRD_TOOL
+
+TOOL = 'ocrd-tesserocr-segment-table'
+LOG = getLogger('processor.TesserocrSegmentTable')
+
+class TesserocrSegmentTable(Processor):
+
+    def __init__(self, *args, **kwargs):
+        kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
+        kwargs['version'] = OCRD_TOOL['version']
+        super(TesserocrSegmentTable, self).__init__(*args, **kwargs)
+
+    def process(self):
+        """Performs table cell segmentation with Tesseract on the workspace.
+        
+        Open and deserialize PAGE input files and their respective images,
+        then iterate over the element hierarchy down to the block level
+        for table regions. If ``overwrite_regions`` is enabled and any
+        layout annotation already exists inside, then remove it.
+        
+        Set up Tesseract to detect text blocks (as table cells).
+        (This is not Tesseract's internal table structure recognition,
+        but the general page segmentation.)
+        Add each to the block at the detected coordinates.
+        
+        Produce a new output file by serialising the resulting hierarchy.
+        """
+        overwrite_regions = self.parameter['overwrite_regions']
+        
+        with PyTessBaseAPI(path=TESSDATA_PREFIX) as tessapi:
+            # disable table detection here, so tables will be
+            # analysed as independent text/line blocks:
+            tessapi.SetVariable("textord_tabfind_find_tables", "0")
+            # this should yield additional blocks within the table blocks
+            # from the page iterator, but does not in fact (yet?):
+            #tessapi.SetVariable("textord_tablefind_recognize_tables", "1")
+            for (n, input_file) in enumerate(self.input_files):
+                page_id = input_file.pageId or input_file.ID
+                LOG.info("INPUT FILE %i / %s", n, page_id)
+                pcgts = page_from_file(self.workspace.download_file(input_file))
+                page = pcgts.get_Page()
+                
+                # add metadata about this operation and its runtime parameters:
+                metadata = pcgts.get_Metadata() # ensured by from_file()
+                metadata.add_MetadataItem(
+                    MetadataItemType(type_="processingStep",
+                                     name=self.ocrd_tool['steps'][0],
+                                     value=TOOL,
+                                     Labels=[LabelsType(
+                                         externalModel="ocrd-tool",
+                                         externalId="parameters",
+                                         Label=[LabelType(type_=name,
+                                                          value=self.parameter[name])
+                                                for name in self.parameter.keys()])]))
+
+                page_image, page_coords, page_image_info = self.workspace.image_from_page(
+                    page, page_id)
+                if page_image_info.resolution != 1:
+                    dpi = page_image_info.resolution
+                    if page_image_info.resolutionUnit == 'cm':
+                        dpi = round(dpi * 2.54)
+                    LOG.info("setting user defined DPI %d from metadata", dpi)
+                    tessapi.SetVariable('user_defined_dpi', str(dpi))
+                tessapi.SetVariable('textord_occupancy_threshold', '0.1')
+                #
+                # prepare dict of reading order
+                reading_order = dict()
+                ro = page.get_ReadingOrder()
+                if not ro:
+                    LOG.warning("Page '%s' contains no ReadingOrder", page_id)
+                    rogroup = None
+                else:
+                    rogroup = ro.get_OrderedGroup() or ro.get_UnorderedGroup()
+                    ordered = False
+                    if isinstance(rogroup, (OrderedGroupType, OrderedGroupIndexedType)):
+                        regionrefs = (rogroup.get_RegionRefIndexed() +
+                                      rogroup.get_OrderedGroupIndexed() +
+                                      rogroup.get_UnorderedGroupIndexed())
+                        ordered = True
+                    if isinstance(rogroup, (UnorderedGroupType, UnorderedGroupIndexedType)):
+                        regionrefs = (rogroup.get_RegionRef() +
+                                      rogroup.get_OrderedGroup() +
+                                      rogroup.get_UnorderedGroup())
+                    for elem in regionrefs:
+                        reading_order[elem.get_regionRef()] = elem
+                        if not isinstance(elem, (RegionRefType, RegionRefIndexedType)):
+                            # recursive
+                            #_plausibilize_group(regions, elem, mark_for_deletion)
+                            pass
+                #
+                # dive into regions
+                regions = page.get_TableRegion()
+                for region in regions:
+                    # delete or warn of existing regions:
+                    if region.get_TextRegion():
+                        if overwrite_regions:
+                            LOG.info('removing existing TextRegions in block "%s" of page "%s"', region.id, page_id)
+                            for subregion in region.get_TextRegion():
+                                if subregion.id in reading_order:
+                                    regionref = reading_order[subregion.id]
+                                    # could be any of the 6 types above:
+                                    regionrefs = rogroup.__getattribute__(regionref.__class__.__name__.replace('Type', ''))
+                                    # remove in-place
+                                    regionrefs.remove(regionref)
+                            region.set_TextRegion([])
+                        else:
+                            LOG.warning('keeping existing TextRegions in block "%s" of page "%s"', region.id, page_id)
+                    # get region image
+                    region_image, region_coords = self.workspace.image_from_segment(
+                        region, page_image, page_coords)
+                    tessapi.SetImage(region_image)
+                    LOG.info("Detecting table cells in region '%s'", region.id)
+                    #
+                    # detect the region segments:
+                    tessapi.SetPageSegMode(PSM.AUTO) # treat table like page
+                    layout = tessapi.AnalyseLayout()
+                    roelem = reading_order.get(region.id)
+                    if not roelem:
+                        LOG.warning("Page '%s' table region '%s' is not referenced in reading order (%s)",
+                                    page_id, region.id, "no target to add cells into")
+                    elif isinstance(roelem, (OrderedGroupType, OrderedGroupIndexedType)):
+                        LOG.warning("Page '%s' table region '%s' already has an ordered group (%s)",
+                                    page_id, region.id, "cells will be appended")
+                    elif isinstance(roelem, (UnorderedGroupType, UnorderedGroupIndexedType)):
+                        LOG.warning("Page '%s' table region '%s' already has an unordered group (%s)",
+                                    page_id, region.id, "cells will not be appended")
+                        roelem = None
+                    elif isinstance(roelem, (RegionRefType, RegionRefIndexedType)):
+                        # replace regionref by group with same index and ref
+                        # (which can then take the cells as subregions)
+                        if ordered:
+                            roelem2 = OrderedGroupIndexedType(id=region.id + '_order',
+                                                              index=roelem.index,
+                                                              regionRef=roelem.regionRef)
+                            roelem.parent_object_.add_OrderedGroupIndexed(roelem2)
+                            roelem.parent_object_.get_RegionRefIndexed().remove(roelem)
+                        else:
+                            roelem2 = OrderedGroupType(id=region.id + '_order',
+                                                       regionRef=roelem.regionRef)
+                            roelem.parent_object_.add_OrderedGroup(roelem2)
+                            roelem.parent_object_.get_RegionRef().remove(roelem)
+                        roelem = roelem2
+                    self._process_region(layout, region, roelem, region_image, region_coords)
+                    
+                # Use input_file's basename for the new file -
+                # this way the files retain the same basenames:
+                file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
+                if file_id == input_file.ID:
+                    file_id = concat_padded(self.output_file_grp, n)
+                self.workspace.add_file(
+                    force=True,
+                    ID=file_id,
+                    file_grp=self.output_file_grp,
+                    pageId=input_file.pageId,
+                    mimetype=MIMETYPE_PAGE,
+                    local_filename=os.path.join(self.output_file_grp,
+                                                file_id + '.xml'),
+                    content=to_xml(pcgts))
+
+    def _process_region(self, it, region, rogroup, region_image, region_coords):
+        # equivalent to GetComponentImages with raw_image=True,
+        # (which would also give raw coordinates),
+        # except we are also interested in the iterator's BlockType() here,
+        index = 0
+        if rogroup:
+            for elem in (rogroup.get_RegionRefIndexed() +
+                         rogroup.get_OrderedGroupIndexed() +
+                         rogroup.get_UnorderedGroupIndexed()):
+                if elem.index >= index:
+                    index = elem.index + 1
+        while it and not it.Empty(RIL.BLOCK):
+            bbox = it.BoundingBox(RIL.BLOCK)
+            polygon = polygon_from_x0y0x1y1(bbox)
+            polygon = coordinates_for_segment(polygon, region_image, region_coords)
+            points = points_from_polygon(polygon)
+            coords = CoordsType(points=points)
+            # if xywh['w'] < 30 or xywh['h'] < 30:
+            #     LOG.info('Ignoring too small region: %s', points)
+            #     it.Next(RIL.BLOCK)
+            #     continue
+            #
+            # the region reference in the reading order element
+            #
+            ID = region.id + "_%04d" % index
+            subregion = TextRegionType(id=ID, Coords=coords,
+                                       type=TextTypeSimpleType.PARAGRAPH)
+            block_type = it.BlockType()
+            if block_type == PT.FLOWING_TEXT:
+                pass
+            elif block_type == PT.HEADING_TEXT:
+                subregion.set_type(TextTypeSimpleType.HEADING)
+            elif block_type == PT.PULLOUT_TEXT:
+                subregion.set_type(TextTypeSimpleType.FLOATING)
+            elif block_type == PT.CAPTION_TEXT:
+                subregion.set_type(TextTypeSimpleType.CAPTION)
+            elif block_type == PT.VERTICAL_TEXT:
+                subregion.set_orientation(90.0)
+            else:
+                it.Next(RIL.BLOCK)
+                continue
+            LOG.info("Detected cell '%s': %s (%s)", ID, points, membername(PT, block_type))
+            region.add_TextRegion(subregion)
+            if rogroup:
+                rogroup.add_RegionRefIndexed(RegionRefIndexedType(regionRef=ID, index=index))
+            #
+            # iterator increment
+            #
+            index += 1
+            it.Next(RIL.BLOCK)

--- a/ocrd_tesserocr/segment_table.py
+++ b/ocrd_tesserocr/segment_table.py
@@ -65,12 +65,10 @@ class TesserocrSegmentTable(Processor):
         overwrite_regions = self.parameter['overwrite_regions']
         
         with PyTessBaseAPI(path=TESSDATA_PREFIX) as tessapi:
-            # disable table detection here, so tables will be
-            # analysed as independent text/line blocks:
+            # disable table detection here, so we won't get
+            # tables inside tables, but try to analyse them as
+            # independent text/line blocks:
             tessapi.SetVariable("textord_tabfind_find_tables", "0")
-            # this should yield additional blocks within the table blocks
-            # from the page iterator, but does not in fact (yet?):
-            #tessapi.SetVariable("textord_tablefind_recognize_tables", "1")
             for (n, input_file) in enumerate(self.input_files):
                 page_id = input_file.pageId or input_file.ID
                 LOG.info("INPUT FILE %i / %s", n, page_id)
@@ -215,8 +213,8 @@ class TesserocrSegmentTable(Processor):
             #     it.Next(RIL.BLOCK)
             #     continue
             #
-            # the region reference in the reading order element
-            #
+            # add the region reference in the reading order element
+            # (but ignore non-text regions entirely)
             ID = region.id + "_%04d" % index
             subregion = TextRegionType(id=ID, Coords=coords,
                                        type=TextTypeSimpleType.PARAGRAPH)

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ Installs five executables:
 
     - ocrd_tesserocr_recognize
     - ocrd_tesserocr_segment_region
+    - ocrd_tesserocr_segment_table
     - ocrd_tesserocr_segment_line
     - ocrd_tesserocr_segment_word
     - ocrd_tesserocr_crop
@@ -33,6 +34,7 @@ setup(
         'console_scripts': [
             'ocrd-tesserocr-recognize=ocrd_tesserocr.cli:ocrd_tesserocr_recognize',
             'ocrd-tesserocr-segment-region=ocrd_tesserocr.cli:ocrd_tesserocr_segment_region',
+            'ocrd-tesserocr-segment-table=ocrd_tesserocr.cli:ocrd_tesserocr_segment_table',
             'ocrd-tesserocr-segment-line=ocrd_tesserocr.cli:ocrd_tesserocr_segment_line',
             'ocrd-tesserocr-segment-word=ocrd_tesserocr.cli:ocrd_tesserocr_segment_word',
             'ocrd-tesserocr-crop=ocrd_tesserocr.cli:ocrd_tesserocr_crop',


### PR DESCRIPTION
This fixes #101 (using raw_lines by default for textline images, but there are still some corner cases that need to be fixed in Tesseract) and brings a number of segmentation-related improvements:
- interprete `overwrite_regions` more consistently
- annotate `@orientation` (independent of dedicated deskewing processor) for vertical and `@type` for all other text blocks
- no separators and noise regions in reading order
- segment tables into cells and lines so they can be OCRed, too