### PR TITLE
all: add dpi parameter as manual override to image metadata

### DIFF
--- a/ocrd_tesserocr/crop.py
+++ b/ocrd_tesserocr/crop.py
@@ -94,10 +94,18 @@ class TesserocrCrop(Processor):
                     # image must not have been rotated or cropped already,
                     # abort if no such image can be produced:
                     feature_filter='deskewed,cropped')
-                if page_image_info.resolution != 1:
+                if self.parameter['dpi'] > 0:
+                    dpi = self.parameter['dpi']
+                    LOG.info("Page '%s' images will use %d DPI from parameter override", page_id, dpi)
+                elif page_image_info.resolution != 1:
                     dpi = page_image_info.resolution
                     if page_image_info.resolutionUnit == 'cm':
                         dpi = round(dpi * 2.54)
+                    LOG.info("Page '%s' images will use %d DPI from image meta-data", page_id, dpi)
+                else:
+                    dpi = 0
+                    LOG.info("Page '%s' images will use DPI estimated from segmentation", page_id)
+                if dpi:
                     tessapi.SetVariable('user_defined_dpi', str(dpi))
                     zoom = 300 / dpi
                 else:

--- a/ocrd_tesserocr/deskew.py
+++ b/ocrd_tesserocr/deskew.py
@@ -100,11 +100,20 @@ class TesserocrDeskew(Processor):
                     # (we will overwrite @orientation anyway,)
                     # abort if no such image can be produced:
                     feature_filter='deskewed' if oplevel == 'page' else '')
-                if page_image_info.resolution != 1:
+                if self.parameter['dpi'] > 0:
+                    dpi = self.parameter['dpi']
+                    LOG.info("Page '%s' images will use %d DPI from parameter override", page_id, dpi)
+                elif page_image_info.resolution != 1:
                     dpi = page_image_info.resolution
                     if page_image_info.resolutionUnit == 'cm':
                         dpi = round(dpi * 2.54)
+                    LOG.info("Page '%s' images will use %d DPI from image meta-data", page_id, dpi)
+                else:
+                    dpi = 0
+                    LOG.info("Page '%s' images will use DPI estimated from segmentation", page_id)
+                if dpi:
                     tessapi.SetVariable('user_defined_dpi', str(dpi))
+                
                 LOG.info("Deskewing on '%s' level in page '%s'", oplevel, page_id)
                 
                 if oplevel == 'page':

--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -16,6 +16,12 @@
       ],
       "steps": ["preprocessing/optimization/deskewing"],
       "parameters": {
+        "dpi": {
+          "type": "number",
+          "format": "float",
+          "description": "pixel density in dots per inch (overrides any meta-data in the images); disabled when negative",
+          "default": -1
+        },
         "operation_level": {
           "type": "string",
           "enum": ["page","region"],
@@ -45,6 +51,12 @@
       ],
       "steps": ["recognition/text-recognition"],
       "parameters": {
+        "dpi": {
+          "type": "number",
+          "format": "float",
+          "description": "pixel density in dots per inch (overrides any meta-data in the images); disabled when negative",
+          "default": -1
+        },
         "textequiv_level": {
           "type": "string",
           "enum": ["region", "line", "word", "glyph"],
@@ -81,6 +93,12 @@
       ],
       "steps": ["layout/segmentation/region"],
       "parameters": {
+        "dpi": {
+          "type": "number",
+          "format": "float",
+          "description": "pixel density in dots per inch (overrides any meta-data in the images); disabled when negative",
+          "default": -1
+        },
         "overwrite_regions": {
           "type": "boolean",
           "default": true,
@@ -117,6 +135,12 @@
       ],
       "steps": ["layout/segmentation/region"],
       "parameters": {
+        "dpi": {
+          "type": "number",
+          "format": "float",
+          "description": "pixel density in dots per inch (overrides any meta-data in the images); disabled when negative",
+          "default": -1
+        },
         "overwrite_regions": {
           "type": "boolean",
           "default": true,
@@ -137,6 +161,12 @@
       ],
       "steps": ["layout/segmentation/line"],
       "parameters": {
+        "dpi": {
+          "type": "number",
+          "format": "float",
+          "description": "pixel density in dots per inch (overrides any meta-data in the images); disabled when negative",
+          "default": -1
+        },
         "overwrite_lines": {
           "type": "boolean",
           "default": true,
@@ -157,6 +187,12 @@
       ],
       "steps": ["layout/segmentation/word"],
       "parameters": {
+        "dpi": {
+          "type": "number",
+          "format": "float",
+          "description": "pixel density in dots per inch (overrides any meta-data in the images); disabled when negative",
+          "default": -1
+        },
         "overwrite_words": {
           "type": "boolean",
           "default": true,
@@ -176,6 +212,12 @@
       ],
       "steps": ["preprocessing/optimization/cropping"],
       "parameters" : {
+        "dpi": {
+          "type": "number",
+          "format": "float",
+          "description": "pixel density in dots per inch (overrides any meta-data in the images); disabled when negative",
+          "default": -1
+        },
         "padding": {
           "type": "number",
           "format": "integer",

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -155,12 +155,19 @@ class TesserocrRecognize(Processor):
                                                 for name in self.parameter.keys()])]))
                 page_image, page_xywh, page_image_info = self.workspace.image_from_page(
                     page, page_id)
-                if page_image_info.resolution != 1:
+                if self.parameter['dpi'] > 0:
+                    dpi = self.parameter['dpi']
+                    LOG.info("Page '%s' images will use %d DPI from paramter override", page_id, dpi)
+                elif page_image_info.resolution != 1:
                     dpi = page_image_info.resolution
                     if page_image_info.resolutionUnit == 'cm':
                         dpi = round(dpi * 2.54)
+                    LOG.info("Page '%s' images will use %d DPI from image meta-data", page_id, dpi)
+                else:
+                    dpi = 0
+                    LOG.info("Page '%s' images will use DPI estimated from segmentation", page_id)
+                if dpi:
                     tessapi.SetVariable('user_defined_dpi', str(dpi))
-                #tessapi.SetImage(page_image)
                 
                 LOG.info("Processing page '%s'", page_id)
                 regions = itertools.chain.from_iterable(

--- a/ocrd_tesserocr/segment_line.py
+++ b/ocrd_tesserocr/segment_line.py
@@ -76,10 +76,18 @@ class TesserocrSegmentLine(Processor):
                 
                 page_image, page_coords, page_image_info = self.workspace.image_from_page(
                     page, page_id)
-                if page_image_info.resolution != 1:
+                if self.parameter['dpi'] > 0:
+                    dpi = self.parameter['dpi']
+                    LOG.info("Page '%s' images will use %d DPI from parameter override", page_id, dpi)
+                elif page_image_info.resolution != 1:
                     dpi = page_image_info.resolution
                     if page_image_info.resolutionUnit == 'cm':
                         dpi = round(dpi * 2.54)
+                    LOG.info("Page '%s' images will use %d DPI from image meta-data", page_id, dpi)
+                else:
+                    dpi = 0
+                    LOG.info("Page '%s' images will use DPI estimated from segmentation", page_id)
+                if dpi:
                     tessapi.SetVariable('user_defined_dpi', str(dpi))
                 
                 for region in itertools.chain.from_iterable(

--- a/ocrd_tesserocr/segment_region.py
+++ b/ocrd_tesserocr/segment_region.py
@@ -75,7 +75,7 @@ class TesserocrSegmentRegion(Processor):
                 # this should yield additional blocks within the table blocks
                 # from the page iterator, but does not in fact (yet?):
                 # (and it can run into assertion errors when the table structure
-                #  does not meet certain homogenity expectations)
+                #  does not meet certain homogeneity expectations)
                 #tessapi.SetVariable("textord_tablefind_recognize_tables", "1")
             else:
                 # disable table detection here, so tables will be
@@ -141,10 +141,18 @@ class TesserocrSegmentRegion(Processor):
                 
                 page_image, page_coords, page_image_info = self.workspace.image_from_page(
                     page, page_id)
-                if page_image_info.resolution != 1:
+                if self.parameter['dpi'] > 0:
+                    dpi = self.parameter['dpi']
+                    LOG.info("Page '%s' images will use %d DPI from parameter override", page_id, dpi)
+                elif page_image_info.resolution != 1:
                     dpi = page_image_info.resolution
                     if page_image_info.resolutionUnit == 'cm':
                         dpi = round(dpi * 2.54)
+                    LOG.info("Page '%s' images will use %d DPI from image meta-data", page_id, dpi)
+                else:
+                    dpi = 0
+                    LOG.info("Page '%s' images will use DPI estimated from segmentation", page_id)
+                if dpi:
                     tessapi.SetVariable('user_defined_dpi', str(dpi))
                 
                 LOG.info("Detecting regions in page '%s'", page_id)

--- a/ocrd_tesserocr/segment_table.py
+++ b/ocrd_tesserocr/segment_table.py
@@ -91,11 +91,18 @@ class TesserocrSegmentTable(Processor):
 
                 page_image, page_coords, page_image_info = self.workspace.image_from_page(
                     page, page_id)
-                if page_image_info.resolution != 1:
+                if self.parameter['dpi'] > 0:
+                    dpi = self.parameter['dpi']
+                    LOG.info("Page '%s' images will use %d DPI from parameter override", page_id, dpi)
+                elif page_image_info.resolution != 1:
                     dpi = page_image_info.resolution
                     if page_image_info.resolutionUnit == 'cm':
                         dpi = round(dpi * 2.54)
-                    LOG.info("setting user defined DPI %d from metadata", dpi)
+                    LOG.info("Page '%s' images will use %d DPI from image meta-data", page_id, dpi)
+                else:
+                    dpi = 0
+                    LOG.info("Page '%s' images will use DPI estimated from segmentation", page_id)
+                if dpi:
                     tessapi.SetVariable('user_defined_dpi', str(dpi))
 
                 #

--- a/ocrd_tesserocr/segment_word.py
+++ b/ocrd_tesserocr/segment_word.py
@@ -71,10 +71,18 @@ class TesserocrSegmentWord(Processor):
                                                 for name in self.parameter.keys()])]))
                 page_image, page_coords, page_image_info = self.workspace.image_from_page(
                     page, page_id)
-                if page_image_info.resolution != 1:
+                if self.parameter['dpi'] > 0:
+                    dpi = self.parameter['dpi']
+                    LOG.info("Page '%s' images will use %d DPI from parameter override", page_id, dpi)
+                elif page_image_info.resolution != 1:
                     dpi = page_image_info.resolution
                     if page_image_info.resolutionUnit == 'cm':
                         dpi = round(dpi * 2.54)
+                    LOG.info("Page '%s' images will use %d DPI from image meta-data", page_id, dpi)
+                else:
+                    dpi = 0
+                    LOG.info("Page '%s' images will use DPI estimated from segmentation", page_id)
+                if dpi:
                     tessapi.SetVariable('user_defined_dpi', str(dpi))
                 
                 for region in page.get_TextRegion():


### PR DESCRIPTION
Fixes #102. 

This does influence segmentation and OSD a lot, but not so sure about (LSTM) recognition. Maybe we should document this somewhere – it's one of very few parameters we have to influence the quality of Tesseract's layout analysis (i.e. deliberately setting a fake value can improve results).

Note that Tesseract is optimised for modern fonts (which are typically smaller than historic ones) and thus biased against historic prints. So setting higher than factual DPI could be a useful recommendation for block (and maybe even line) segmentation. But this is still conjecture and I have only little evidence supporting it – someone would have to make systematic measurements first.