### PR TITLE
recognize: add char white/un/blacklisting parameters

### DIFF
--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -61,6 +61,21 @@
           "default": false,
           "description": "Do not attempt additional segmentation (baseline+xheight+ascenders/descenders prediction) when using line images (i.e. when textequiv_level<region). Can increase accuracy for certain workflows. Disable when line segments/images may contain components of more than 1 line, or larger gaps/white-spaces."
         },
+        "char_whitelist": {
+          "type": "string",
+          "default": "",
+          "description": "Enumeration of character hypotheses (from the model) to allow exclusively; overruled by blacklist if set."
+        },
+        "char_blacklist": {
+          "type": "string",
+          "default": "",
+          "description": "Enumeration of character hypotheses (from the model) to suppress; overruled by unblacklist if set."
+        },
+        "char_unblacklist": {
+          "type": "string",
+          "default": "",
+          "description": "Enumeration of character hypotheses (from the model) to allow inclusively."
+        },
         "model": {
           "type": "string",
           "description": "tessdata model to apply (an ISO 639-3 language specification or some other basename, e.g. deu-frak or Fraktur)"

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -88,6 +88,13 @@ class TesserocrRecognize(Processor):
         with PyTessBaseAPI(path=TESSDATA_PREFIX, lang=model) as tessapi:
             LOG.info("Using model '%s' in %s for recognition at the %s level",
                      model, get_languages()[0], maxlevel)
+            # TODO: maybe warn/raise when illegal combinations or characters not in the model unicharset?
+            if self.parameter['char_whitelist']:
+                tessapi.SetVariable("tessedit_char_whitelist", self.parameter['char_whitelist'])
+            if self.parameter['char_blacklist']:
+                tessapi.SetVariable("tessedit_char_blacklist", self.parameter['char_blacklist'])
+            if self.parameter['char_unblacklist']:
+                tessapi.SetVariable("tessedit_char_unblacklist", self.parameter['char_unblacklist'])
             # todo: populate GetChoiceIterator() with LSTM models, too:
             #tessapi.SetVariable("lstm_choice_mode", "2")
             # todo: determine relevancy of these variables:


### PR DESCRIPTION
Fixes #107.

Can be quite useful when looking at the unicharset, e.g.:
```sh
combine_tessdata -e /usr/local/share/tessdata/Fraktur.traineddata Fraktur.lstm-unicharset
less Fraktur.lstm-unicharset
ocrd-tesserocr-recognize -I OCR-D-SEG-LINE -O OCR-D-OCR-TESS -p '{"char_blacklist": "_[]{}|®©@€"}'
```

I am not so sure how to handle **normalization** for historic texts, though. We could offer Unicode `NFC` and `NFKC`, but they don't fit so well into our GT transcription level scheme (for which we still have no implementation BTW; if have only [started](https://github.com/ASVLeipzig/cor-asv-ann/blob/39cae08964cce754471248065a89a48808fd43e9/ocrd_cor_asv_ann/lib/alignment.py#L302) this for my module). But the standard models do contain characters that we don't want in levels 1 and 2, e.g.:
- `ﬀ`
- `ﬆ`
- `ﬄ`
- `ﬅ`
