### PR TITLE
segment-region: add Tesseract's sparse_text mode

### DIFF
--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -134,6 +134,11 @@
           "type": "boolean",
           "default": true,
           "description": "recognise tables as table regions (textord_tabfind_find_tables)"
+        },
+        "sparse_text": {
+          "type": "boolean",
+          "default": false,
+          "description": "use 'sparse text' page segmentation mode (find as much text as possible in no particular order): only text regions, single lines without vertical or horizontal space"
         }
       }
     },

--- a/ocrd_tesserocr/segment_region.py
+++ b/ocrd_tesserocr/segment_region.py
@@ -157,7 +157,7 @@ class TesserocrSegmentRegion(Processor):
                 
                 LOG.info("Detecting regions in page '%s'", page_id)
                 tessapi.SetImage(page_image) # is already cropped to Border
-                tessapi.SetPageSegMode(PSM.AUTO) # (default)
+                tessapi.SetPageSegMode(PSM.SPARSE_TEXT if self.parameter['sparse_text'] else PSM.AUTO)
 
                 # detect the region segments and types:
                 layout = tessapi.AnalyseLayout()


### PR DESCRIPTION
### Rationale

Tesseract offers a special page segmentation mode for text scattered arbitrarily across the page, called `PSM_SPARSE_TEXT` (or `PSM_SPARSE`). It tries to recover as much text as possible without paying attention to size, order or non-text foreground, delivering text regions without vertical spaces (i.e. only single lines) or horizontal spaces exceeding single blanks (i.e. tabs). It is based on Tesseract's internal textline recognition, without any re-partitioning or column/table detection logic. (But it does undergo internal image and vertical/horizontal line suppression.)

This can be useful in itself for tasks that try to find some text anywhere on pages, but also as an auxiliary step in regular (i.e. full) page segmentation methods. For example, one can combine this with other (perhaps even data-driven) segmentations, or use OCR as an intermediate step in guiding them.

Example:

![ocrd-segment-region-sparse-text](https://user-images.githubusercontent.com/38561704/76253290-b3b05080-624a-11ea-9b9e-2d25a523411c.png)

(Of course, running this step after text-image segmentation – suppression of non-text – from other modules is worthwhile, too.)
