### PR TITLE
fix reference before assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+Fixed:
+
+  * recognize: ignore empty RO group
+
 ## [0.8.2] - 2020-04-08
 
 Fixed:

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -420,6 +420,7 @@ def page_get_reading_order(ro, rogroup):
     and an object ``rogroup`` with additional ReadingOrder element objects,
     add all references to the dict, traversing the group recursively.
     """
+    regionrefs = list()
     if isinstance(rogroup, (OrderedGroupType, OrderedGroupIndexedType)):
         regionrefs = (rogroup.get_RegionRefIndexed() +
                       rogroup.get_OrderedGroupIndexed() +


### PR DESCRIPTION
As a side-effect of https://github.com/OCR-D/ocrd_segment/pull/38 also the tesserocr modul suffers from the same blank-page-problem (bpp^TM).

```
12:43:06.939 INFO processor.TesserocrRecognize - Processing page 'IMG_OCR-D-DEWARP_1246715'
Traceback (most recent call last):
  File "/usr/bin/ocrd-tesserocr-recognize", line 11, in <module>
    load_entry_point('ocrd-tesserocr', 'console_scripts', 'ocrd-tesserocr-recognize')()
  File "/usr/lib/python3.6/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/build/ocrd_tesserocr/ocrd_tesserocr/cli.py", line 36, in ocrd_tesserocr_recognize
    return ocrd_cli_wrap_processor(TesserocrRecognize, *args, **kwargs)
  File "/build/core/ocrd/ocrd/decorators.py", line 54, in ocrd_cli_wrap_processor
    run_processor(processorClass, ocrd_tool, mets, workspace=workspace, **kwargs)
  File "/build/core/ocrd/ocrd/processor/base.py", line 57, in run_processor
    processor.process()
  File "/build/ocrd_tesserocr/ocrd_tesserocr/recognize.py", line 189, in process
    page_update_higher_textequiv_levels(maxlevel, pcgts)
  File "/build/ocrd_tesserocr/ocrd_tesserocr/recognize.py", line 470, in page_update_higher_textequiv_levels
    page_get_reading_order(reading_order, ro.get_OrderedGroup() or ro.get_UnorderedGroup())
  File "/build/ocrd_tesserocr/ocrd_tesserocr/recognize.py", line 431, in page_get_reading_order
    for elem in regionrefs:
UnboundLocalError: local variable 'regionrefs' referenced before assignment
Makefile:304: recipe for target 'OCR-D-OCR-TESS-Fraktur' failed
make[1]: *** [OCR-D-OCR-TESS-Fraktur] Error 1
make[1]: Leaving directory '/data'
Makefile:194: recipe for target '.' failed
make: Leaving directory '/data'
make: *** [.] Error 2

```