### PR TITLE
Recognize with padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [0.8.3] - 2020-05-12
+
 Fixed:
 
   * recognize: ignore empty RO group
+
+Changed:
+
+  * recognize: add `padding` parameter
 
 ## [0.8.2] - 2020-04-08
 

--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -68,6 +68,12 @@
           "default": false,
           "description": "Remove existing layout and text annotation below the TextLine level (regardless of textequiv_level)."
         },
+        "padding": {
+          "type": "number",
+          "format": "integer",
+          "default": 0,
+          "description": "Number of background-filled pixels to add around the line image (i.e. the annotated AlternativeImage if it exists or the higher-level image cropped to the bounding box and masked by the polygon otherwise) on each side before recognition."
+        },
         "raw_lines": {
           "type": "boolean",
           "default": false,

--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.2",
+  "version": "0.8.3",
   "git_url": "https://github.com/OCR-D/ocrd_tesserocr",
   "dockerhub": "ocrd/tesserocr",
   "tools": {


### PR DESCRIPTION
This was on our to-do list for a long time – I don't know just why we did not just do it.

This is for cases where the line polygon is quite close to the foreground and there is no `AlternativeImage` with some padding around the margins (as `ocrd-cis-ocropy-dewarp` would yield). AFAICT Tesseract needs some margin (I'd say at least 5px) for good recognition.