### PR TITLE
segment-region: clip polygons to parent...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+Fixed:
+
+  * segment-region: ensure polygons are within page/Border
+
 Changed:
 
   * segment-region: in `sparse_text` mode, also add text lines


### PR DESCRIPTION
(before annotating polygon coordinates, ensure they fit
 into their parent if it exists, or the page frame otherwise)

This happens for example when the page was deskewed and the region is already on the edge of the (rotated, enlarged) page frame. So the result would be syntactically invalid. 

This is another (previously undetected) instance of https://github.com/OCR-D/core/issues/489, with the [same solution](https://github.com/cisocrgroup/ocrd_cis/pull/48/commits/01638c45d6b777adccf03ad457e2b75909ea107f).