### PR TITLE
Set path to TESSDATA_PREFIX for get_languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Changed:
 
 Fixed:
 
-  * Debug statements listed the wrong model paths, #129
+  * Always set path to `TESSDATA_PREFIX` for `tesserocr.get_languages`, #129
 
 ## [0.8.3] - 2020-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Changed:
 
   * segment-region: in `sparse_text` mode, also add text lines
 
+Fixed:
+
+  * Debug statements listed the wrong model paths, #129
+
 ## [0.8.3] - 2020-05-12
 
 Fixed:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV PYTHONIOENCODING utf8
 
 WORKDIR /build-ocrd
 COPY setup.py .
+COPY ocrd_tesserocr/ocrd-tool.json .
 COPY README.md .
 COPY requirements.txt .
 COPY requirements_test.txt .

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -5,7 +5,7 @@ from PIL import Image, ImageStat
 
 from tesserocr import (
     RIL, PSM,
-    PyTessBaseAPI, get_languages)
+    PyTessBaseAPI, get_languages as get_languages_)
 
 from ocrd_utils import (
     getLogger,
@@ -45,6 +45,12 @@ LOG = getLogger('processor.TesserocrRecognize')
 
 CHOICE_THRESHOLD_NUM = 6 # maximum number of choices to query and annotate
 CHOICE_THRESHOLD_CONF = 0.2 # maximum score drop from best choice to query and annotate
+
+def get_languages(*args, **kwargs):
+    """
+    Wraps tesserocr.get_languages() with a fixed path parameter.
+    """
+    return get_languages_(*args, path=TESSDATA_PREFIX, **kwargs)
 
 class TesserocrRecognize(Processor):
 


### PR DESCRIPTION
Wraps `tesserocr.get_languages` with path set to `TESSDATA_PREFIX`.