### PR TITLE
binarize/crop: put derived images under output fileGrp…

### DIFF
--- a/ocrd_tesserocr/binarize.py
+++ b/ocrd_tesserocr/binarize.py
@@ -24,7 +24,6 @@ from .config import TESSDATA_PREFIX, OCRD_TOOL
 
 TOOL = 'ocrd-tesserocr-binarize'
 LOG = getLogger('processor.TesserocrBinarize')
-FALLBACK_IMAGE_GRP = 'OCR-D-IMG-BIN'
 
 class TesserocrBinarize(Processor):
 
@@ -32,13 +31,6 @@ class TesserocrBinarize(Processor):
         kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         kwargs['version'] = OCRD_TOOL['version']
         super(TesserocrBinarize, self).__init__(*args, **kwargs)
-        if hasattr(self, 'output_file_grp'):
-            try:
-                self.page_grp, self.image_grp = self.output_file_grp.split(',')
-            except ValueError:
-                self.page_grp = self.output_file_grp
-                self.image_grp = FALLBACK_IMAGE_GRP
-                LOG.info("No output file group for images specified, falling back to '%s'", FALLBACK_IMAGE_GRP)
 
     def process(self):
         """Performs binarization of the region / line with Tesseract on the workspace.
@@ -48,18 +40,22 @@ class TesserocrBinarize(Processor):
         
         Set up Tesseract to recognize the segment image's layout, and get
         the binarized image. Create an image file, and reference it as
-        AlternativeImage in the segment element. Add the new image file
-        to the workspace with the fileGrp USE given in the second position
-        of the output fileGrp, or ``OCR-D-IMG-BIN``, and an ID based on input
-        file and input element.
+        AlternativeImage in the segment element.
+        
+        Add the new image file to the workspace along with the output fileGrp,
+        and using a file ID with suffix ``.IMG-BIN`` along with further
+        identification of the input element.
         
         Produce a new output file by serialising the resulting hierarchy.
         """
         oplevel = self.parameter['operation_level']
+        assert len(self.output_file_grp.split(',')) == 1, \
+            "Expected exactly one output file group, but '%s' has %d" % (
+                self.output_file_grp, len(self.output_file_grp.split(',')))
         
         with PyTessBaseAPI(path=TESSDATA_PREFIX) as tessapi:
             for n, input_file in enumerate(self.input_files):
-                file_id = input_file.ID.replace(self.input_file_grp, self.image_grp)
+                file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
                 page_id = input_file.pageId or input_file.ID
                 LOG.info("INPUT FILE %i / %s", n, page_id)
                 pcgts = page_from_file(self.workspace.download_file(input_file))
@@ -108,15 +104,15 @@ class TesserocrBinarize(Processor):
 
                 # Use input_file's basename for the new file -
                 # this way the files retain the same basenames:
-                file_id = input_file.ID.replace(self.input_file_grp, self.page_grp)
+                file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
                 if file_id == input_file.ID:
-                    file_id = concat_padded(self.page_grp, n)
+                    file_id = concat_padded(self.output_file_grp, n)
                 self.workspace.add_file(
                     ID=file_id,
-                    file_grp=self.page_grp,
+                    file_grp=self.output_file_grp,
                     pageId=input_file.pageId,
                     mimetype=MIMETYPE_PAGE,
-                    local_filename=os.path.join(self.page_grp,
+                    local_filename=os.path.join(self.output_file_grp,
                                                 file_id + '.xml'),
                     content=to_xml(pcgts))
 
@@ -131,9 +127,9 @@ class TesserocrBinarize(Processor):
             return
         # update METS (add the image file):
         file_path = self.workspace.save_image_file(image_bin,
-                                    file_id,
+                                    file_id + '.IMG-BIN',
                                     page_id=page_id,
-                                    file_grp=self.image_grp)
+                                    file_grp=self.output_file_grp)
         # update PAGE (reference the image file):
         features = xywh['features'] + ",binarized"
         segment.add_AlternativeImage(AlternativeImageType(

--- a/ocrd_tesserocr/crop.py
+++ b/ocrd_tesserocr/crop.py
@@ -5,6 +5,8 @@ import tesserocr
 from ocrd_utils import (
     getLogger, concat_padded,
     crop_image,
+    make_file_id,
+    assert_file_grp_cardinality,
     bbox_from_points, points_from_bbox, bbox_from_xywh,
     MIMETYPE_PAGE
 )
@@ -47,11 +49,10 @@ class TesserocrCrop(Processor):
         
         Produce new output files by serialising the resulting hierarchy.
         """
-        padding = self.parameter['padding']
-        assert len(self.output_file_grp.split(',')) == 1, \
-            "Expected exactly one output file group, but '%s' has %d" % (
-                self.output_file_grp, len(self.output_file_grp.split(',')))
+        assert_file_grp_cardinality(self.input_file_grp, 1)
+        assert_file_grp_cardinality(self.output_file_grp, 1)
 
+        padding = self.parameter['padding']
         with tesserocr.PyTessBaseAPI(path=TESSDATA_PREFIX) as tessapi:
             # disable table detection here (tables count as text blocks),
             # because we do not want to risk confusing the spine with
@@ -185,7 +186,7 @@ class TesserocrCrop(Processor):
                     page_image = crop_image(page_image,
                         box=(min_x, min_y, max_x, max_y))
                     page_xywh['features'] += ',cropped'
-                    file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
+                    file_id = make_file_id(input_file, self.output_file_grp)
                     if file_id == input_file.ID:
                         file_id = concat_padded(self.output_file_grp, n)
                     file_path = self.workspace.save_image_file(page_image,

--- a/ocrd_tesserocr/crop.py
+++ b/ocrd_tesserocr/crop.py
@@ -187,8 +187,6 @@ class TesserocrCrop(Processor):
                         box=(min_x, min_y, max_x, max_y))
                     page_xywh['features'] += ',cropped'
                     file_id = make_file_id(input_file, self.output_file_grp)
-                    if file_id == input_file.ID:
-                        file_id = concat_padded(self.output_file_grp, n)
                     file_path = self.workspace.save_image_file(page_image,
                                                 file_id + '.IMG-CROP',
                                                 page_id=input_file.pageId,
@@ -199,11 +197,6 @@ class TesserocrCrop(Processor):
                 else:
                     LOG.error("Cannot find valid extent for page '%s'", page_id)
 
-                # Use input_file's basename for the new file -
-                # this way the files retain the same basenames:
-                file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
-                if file_id == input_file.ID:
-                    file_id = concat_padded(self.output_file_grp, n)
                 pcgts.set_pcGtsId(file_id)
                 self.workspace.add_file(
                     ID=file_id,

--- a/ocrd_tesserocr/crop.py
+++ b/ocrd_tesserocr/crop.py
@@ -22,7 +22,6 @@ from .config import TESSDATA_PREFIX, OCRD_TOOL
 
 TOOL = 'ocrd-tesserocr-crop'
 LOG = getLogger('processor.TesserocrCrop')
-FALLBACK_FILEGRP_IMG = 'OCR-D-IMG-CROP'
 
 class TesserocrCrop(Processor):
 
@@ -30,14 +29,6 @@ class TesserocrCrop(Processor):
         kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         kwargs['version'] = OCRD_TOOL['version']
         super(TesserocrCrop, self).__init__(*args, **kwargs)
-        if hasattr(self, 'output_file_grp'):
-            try:
-                self.page_grp, self.image_grp = self.output_file_grp.split(',')
-            except ValueError:
-                self.page_grp = self.output_file_grp
-                self.image_grp = FALLBACK_FILEGRP_IMG
-                LOG.info("No output file group for images specified, falling back to '%s'",
-                         FALLBACK_FILEGRP_IMG)
 
     def process(self):
         """Performs page cropping with Tesseract on the workspace.
@@ -49,13 +40,17 @@ class TesserocrCrop(Processor):
         
         Moreover, crop the original image accordingly, and reference the
         resulting image file as AlternativeImage in the Page element.
-        Add the new image file to the workspace with the fileGrp USE given
-        in the second position of the output fileGrp, or ``OCR-D-IMG-CROP``,
-        and an ID based on input file and input element.
+        
+        Add the new image file to the workspace along with the output fileGrp,
+        and using a file ID with suffix ``.IMG-CROP`` along with further
+        identification of the input element.
         
         Produce new output files by serialising the resulting hierarchy.
         """
         padding = self.parameter['padding']
+        assert len(self.output_file_grp.split(',')) == 1, \
+            "Expected exactly one output file group, but '%s' has %d" % (
+                self.output_file_grp, len(self.output_file_grp.split(',')))
 
         with tesserocr.PyTessBaseAPI(path=TESSDATA_PREFIX) as tessapi:
             # disable table detection here (tables count as text blocks),
@@ -190,13 +185,13 @@ class TesserocrCrop(Processor):
                     page_image = crop_image(page_image,
                         box=(min_x, min_y, max_x, max_y))
                     page_xywh['features'] += ',cropped'
-                    file_id = input_file.ID.replace(self.input_file_grp, self.image_grp)
+                    file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
                     if file_id == input_file.ID:
-                        file_id = concat_padded(self.image_grp, n)
+                        file_id = concat_padded(self.output_file_grp, n)
                     file_path = self.workspace.save_image_file(page_image,
-                                                file_id,
-                                                page_id=page_id,
-                                                file_grp=self.image_grp)
+                                                file_id + '.IMG-CROP',
+                                                page_id=input_file.pageId,
+                                                file_grp=self.output_file_grp)
                     # update PAGE (reference the image file):
                     page.add_AlternativeImage(AlternativeImageType(
                         filename=file_path, comments=page_xywh['features']))
@@ -205,14 +200,14 @@ class TesserocrCrop(Processor):
 
                 # Use input_file's basename for the new file -
                 # this way the files retain the same basenames:
-                file_id = input_file.ID.replace(self.input_file_grp, self.page_grp)
+                file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
                 if file_id == input_file.ID:
-                    file_id = concat_padded(self.page_grp, n)
+                    file_id = concat_padded(self.output_file_grp, n)
                 self.workspace.add_file(
                     ID=file_id,
-                    file_grp=self.page_grp,
+                    file_grp=self.output_file_grp,
                     pageId=input_file.pageId,
                     mimetype=MIMETYPE_PAGE,
-                    local_filename=os.path.join(self.page_grp,
+                    local_filename=os.path.join(self.output_file_grp,
                                                 file_id + '.xml'),
                     content=to_xml(pcgts))

--- a/ocrd_tesserocr/deskew.py
+++ b/ocrd_tesserocr/deskew.py
@@ -75,6 +75,7 @@ class TesserocrDeskew(Processor):
                 page_id = input_file.pageId or input_file.ID
                 LOG.info("INPUT FILE %i / %s", n, page_id)
                 pcgts = page_from_file(self.workspace.download_file(input_file))
+                pcgts.set_pcGtsId(file_id)
                 page = pcgts.get_Page()
                 
                 # add metadata about this operation and its runtime parameters:
@@ -131,12 +132,6 @@ class TesserocrDeskew(Processor):
                                               "region '%s'" % region.id, input_file.pageId,
                                               file_id + '_' + region.id)
                 
-                # Use input_file's basename for the new file -
-                # this way the files retain the same basenames:
-                file_id = input_file.ID.replace(self.input_file_grp, self.page_grp)
-                if file_id == input_file.ID:
-                    file_id = concat_padded(self.page_grp, n)
-                pcgts.set_pcGtsId(file_id)
                 self.workspace.add_file(
                     ID=file_id,
                     file_grp=self.output_file_grp,

--- a/ocrd_tesserocr/segment_line.py
+++ b/ocrd_tesserocr/segment_line.py
@@ -8,6 +8,8 @@ from tesserocr import PyTessBaseAPI, RIL, PSM
 from ocrd import Processor
 from ocrd_utils import (
     getLogger, concat_padded,
+    make_file_id,
+    assert_file_grp_cardinality,
     polygon_from_xywh,
     points_from_polygon,
     coordinates_for_segment,
@@ -49,6 +51,9 @@ class TesserocrSegmentLine(Processor):
         
         Produce a new output file by serialising the resulting hierarchy.
         """
+        assert_file_grp_cardinality(self.input_file_grp, 1)
+        assert_file_grp_cardinality(self.output_file_grp, 1)
+
         overwrite_lines = self.parameter['overwrite_lines']
         
         with PyTessBaseAPI(
@@ -130,11 +135,7 @@ class TesserocrSegmentLine(Processor):
                         region.add_TextLine(TextLineType(
                             id=line_id, Coords=CoordsType(line_points)))
                 
-                # Use input_file's basename for the new file -
-                # this way the files retain the same basenames:
-                file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
-                if file_id == input_file.ID:
-                    file_id = concat_padded(self.output_file_grp, n)
+                file_id = make_file_id(input_file, self.output_file_grp)
                 self.workspace.add_file(
                     ID=file_id,
                     file_grp=self.output_file_grp,

--- a/ocrd_tesserocr/segment_region.py
+++ b/ocrd_tesserocr/segment_region.py
@@ -9,7 +9,8 @@ from tesserocr import (
 
 from ocrd_utils import (
     getLogger,
-    concat_padded,
+    make_file_id,
+    assert_file_grp_cardinality,
     coordinates_for_segment,
     polygon_from_points,
     polygon_from_x0y0x1y1,
@@ -21,7 +22,7 @@ from ocrd_modelfactory import page_from_file
 from ocrd_models.ocrd_page import (
     MetadataItemType,
     LabelsType, LabelType,
-    CoordsType, AlternativeImageType,
+    CoordsType,
     PageType,
     OrderedGroupType,
     ReadingOrderType,
@@ -70,6 +71,9 @@ class TesserocrSegmentRegion(Processor):
         
         Produce a new output file by serialising the resulting hierarchy.
         """
+        assert_file_grp_cardinality(self.input_file_grp, 1)
+        assert_file_grp_cardinality(self.output_file_grp, 1)
+
         overwrite_regions = self.parameter['overwrite_regions']
         find_tables = self.parameter['find_tables']
         
@@ -167,11 +171,7 @@ class TesserocrSegmentRegion(Processor):
                 layout = tessapi.AnalyseLayout()
                 self._process_page(layout, page, page_image, page_coords, input_file.pageId)
                 
-                # Use input_file's basename for the new file -
-                # this way the files retain the same basenames:
-                file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
-                if file_id == input_file.ID:
-                    file_id = concat_padded(self.output_file_grp, n)
+                file_id = make_file_id(input_file, self.output_file_grp)
                 self.workspace.add_file(
                     ID=file_id,
                     file_grp=self.output_file_grp,

--- a/ocrd_tesserocr/segment_table.py
+++ b/ocrd_tesserocr/segment_table.py
@@ -9,6 +9,8 @@ from tesserocr import (
 from ocrd_utils import (
     getLogger,
     concat_padded,
+    make_file_id,
+    assert_file_grp_cardinality,
     coordinates_for_segment,
     polygon_from_x0y0x1y1,
     points_from_polygon,
@@ -63,6 +65,9 @@ class TesserocrSegmentTable(Processor):
         
         Produce a new output file by serialising the resulting hierarchy.
         """
+        assert_file_grp_cardinality(self.input_file_grp, 1)
+        assert_file_grp_cardinality(self.output_file_grp, 1)
+
         overwrite_regions = self.parameter['overwrite_regions']
         
         with PyTessBaseAPI(path=TESSDATA_PREFIX) as tessapi:
@@ -174,11 +179,7 @@ class TesserocrSegmentTable(Processor):
                         roelem = roelem2
                     self._process_region(layout, region, roelem, region_image, region_coords)
                     
-                # Use input_file's basename for the new file -
-                # this way the files retain the same basenames:
-                file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
-                if file_id == input_file.ID:
-                    file_id = concat_padded(self.output_file_grp, n)
+                file_id = make_file_id(input_file, self.output_file_grp)
                 self.workspace.add_file(
                     force=True,
                     ID=file_id,

--- a/ocrd_tesserocr/segment_word.py
+++ b/ocrd_tesserocr/segment_word.py
@@ -6,6 +6,8 @@ from tesserocr import RIL, PyTessBaseAPI, PSM
 from ocrd import Processor
 from ocrd_utils import (
     getLogger, concat_padded,
+    make_file_id,
+    assert_file_grp_cardinality,
     polygon_from_xywh,
     points_from_polygon,
     coordinates_for_segment,
@@ -45,6 +47,9 @@ class TesserocrSegmentWord(Processor):
         
         Produce a new output file by serialising the resulting hierarchy.
         """
+        assert_file_grp_cardinality(self.input_file_grp, 1)
+        assert_file_grp_cardinality(self.output_file_grp, 1)
+
         overwrite_words = self.parameter['overwrite_words']
 
         with PyTessBaseAPI(
@@ -107,11 +112,7 @@ class TesserocrSegmentWord(Processor):
                             line.add_Word(WordType(
                                 id=word_id, Coords=CoordsType(word_points)))
                             
-                # Use input_file's basename for the new file -
-                # this way the files retain the same basenames:
-                file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
-                if file_id == input_file.ID:
-                    file_id = concat_padded(self.output_file_grp, n)
+                file_id = make_file_id(input_file, self.output_file_grp)
                 self.workspace.add_file(
                     ID=file_id,
                     file_grp=self.output_file_grp,


### PR DESCRIPTION
…in fulfillment of OCR-D/spec#164.

@kba same provisions as in cisocrgroup/ocrd_cis#57