### PR TITLE
Set pcGtsId

### DIFF
--- a/ocrd_tesserocr/binarize.py
+++ b/ocrd_tesserocr/binarize.py
@@ -111,6 +111,7 @@ class TesserocrBinarize(Processor):
                 file_id = input_file.ID.replace(self.input_file_grp, self.page_grp)
                 if file_id == input_file.ID:
                     file_id = concat_padded(self.page_grp, n)
+                pcgts.set_pcGtsId(file_id)
                 self.workspace.add_file(
                     ID=file_id,
                     file_grp=self.page_grp,

--- a/ocrd_tesserocr/crop.py
+++ b/ocrd_tesserocr/crop.py
@@ -208,6 +208,7 @@ class TesserocrCrop(Processor):
                 file_id = input_file.ID.replace(self.input_file_grp, self.page_grp)
                 if file_id == input_file.ID:
                     file_id = concat_padded(self.page_grp, n)
+                pcgts.set_pcGtsId(file_id)
                 self.workspace.add_file(
                     ID=file_id,
                     file_grp=self.page_grp,

--- a/ocrd_tesserocr/deskew.py
+++ b/ocrd_tesserocr/deskew.py
@@ -140,6 +140,7 @@ class TesserocrDeskew(Processor):
                 file_id = input_file.ID.replace(self.input_file_grp, self.page_grp)
                 if file_id == input_file.ID:
                     file_id = concat_padded(self.page_grp, n)
+                pcgts.set_pcGtsId(file_id)
                 self.workspace.add_file(
                     ID=file_id,
                     file_grp=self.page_grp,

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -200,6 +200,7 @@ class TesserocrRecognize(Processor):
                 file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
                 if file_id == input_file.ID:
                     file_id = concat_padded(self.output_file_grp, n)
+                pcgts.set_pcGtsId(file_id)
                 self.workspace.add_file(
                     ID=file_id,
                     file_grp=self.output_file_grp,

--- a/ocrd_tesserocr/segment_line.py
+++ b/ocrd_tesserocr/segment_line.py
@@ -135,6 +135,7 @@ class TesserocrSegmentLine(Processor):
                 file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
                 if file_id == input_file.ID:
                     file_id = concat_padded(self.output_file_grp, n)
+                pcgts.set_pcGtsId(file_id)
                 self.workspace.add_file(
                     ID=file_id,
                     file_grp=self.output_file_grp,

--- a/ocrd_tesserocr/segment_region.py
+++ b/ocrd_tesserocr/segment_region.py
@@ -172,6 +172,7 @@ class TesserocrSegmentRegion(Processor):
                 file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
                 if file_id == input_file.ID:
                     file_id = concat_padded(self.output_file_grp, n)
+                pcgts.set_pcGtsId(file_id)
                 self.workspace.add_file(
                     ID=file_id,
                     file_grp=self.output_file_grp,

--- a/ocrd_tesserocr/segment_table.py
+++ b/ocrd_tesserocr/segment_table.py
@@ -179,6 +179,7 @@ class TesserocrSegmentTable(Processor):
                 file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
                 if file_id == input_file.ID:
                     file_id = concat_padded(self.output_file_grp, n)
+                pcgts.set_pcGtsId(file_id)
                 self.workspace.add_file(
                     force=True,
                     ID=file_id,

--- a/ocrd_tesserocr/segment_word.py
+++ b/ocrd_tesserocr/segment_word.py
@@ -112,6 +112,7 @@ class TesserocrSegmentWord(Processor):
                 file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
                 if file_id == input_file.ID:
                     file_id = concat_padded(self.output_file_grp, n)
+                pcgts.set_pcGtsId(file_id)
                 self.workspace.add_file(
                     ID=file_id,
                     file_grp=self.output_file_grp,


### PR DESCRIPTION
OCR-D's validation now requires that the pcGtsId of a PAGE-XML file matches its corresponding mets:file/ID. Set the pcGtsId before adding a file to the workspace.

Fixes OCR-D/ocrd_tesserocr#135.