### PR TITLE
pip install -U pip before pip install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,14 +64,17 @@ deps-ubuntu:
 
 # Install python deps via pip
 deps:
+	$(PIP) install -U pip
 	$(PIP) install -r requirements.txt
 
 # Install testing python deps via pip
 deps-test:
+	$(PIP) install -U pip
 	$(PIP) install -r requirements_test.txt
 
 # Install
 install:
+	$(PIP) install -U pip
 	$(PIP) install .
 
 # Build docker image

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,2 @@
 pytest >= 4.4.0
 coverage >= 4.5.2
-scikit-build

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,3 @@
 pytest >= 4.4.0
 coverage >= 4.5.2
+scikit-build


### PR DESCRIPTION
Let's see whether that fixes the issue. I guess opencv-headless required skbuild but dropped that requirement recently, but haven't checked yet.