### PR TITLE
Polygonalize segments by shrinking to children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ Fixed:
  * segment*/recognize: reduce minimal region height to sane value
  * segment*/recognize: also disable text recognition if `model` is empty
  * segment-{region,line,word}: apply only single-level segmentation again
+ * segment*/recognize: skip empty non-text blocks and all-reject words
 
 Changed:
 
  * segment*/recognize: add option `shrink_polygons`, default to `false`
+ * segment*/recognize: add Tesseract version to meta-data
 
 ## [0.10.0] - 2020-12-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+Fixed:
+
+ * segment/recognize: reduce minimal region height to sane value
+
+Changed:
+
+ * segment/recognize: add option `shrink_polygons`, default to `true`
+
 ## [0.10.0] - 2020-12-01
 
 Fixed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Fixed:
 
 Changed:
 
- * segment/recognize: add option `shrink_polygons`, default to `true`
+ * segment/recognize: add option `shrink_polygons`, default to `false`
 
 ## [0.10.0] - 2020-12-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 Fixed:
 
- * segment/recognize: reduce minimal region height to sane value
+ * segment*/recognize: reduce minimal region height to sane value
+ * segment*/recognize: also disable text recognition if `model` is empty
+ * segment-{region,line,word}: apply only single-level segmentation again
 
 Changed:
 
- * segment/recognize: add option `shrink_polygons`, default to `false`
+ * segment*/recognize: add option `shrink_polygons`, default to `false`
 
 ## [0.10.0] - 2020-12-01
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ It also means that Tesseract should be allowed to segment across multiple hierar
 - prefer `ocrd-tesserocr-recognize` with `segmentation_level=line` over `ocrd-tesserocr-segment-line` followed by `ocrd-tesserocr-recognize`, if you want to do everything but region segmentation with Tesseract,
 - prefer `ocrd-tesserocr-segment` over `ocrd-tesserocr-segment-region` followed by (`ocrd-tesserocr-segment-table` and) `ocrd-tesserocr-segment-line`, if you want to do everything but recognition with Tesseract.
 
-If you do allow segmentation across multiple levels, e.g. by using `ocrd-tesserocr-segment` or `ocrd-tesserocr-recognize` with `segmentation_level` higher than `textequiv_level`, then you can also post-process to shrink parents to **polygons** by their constituent outlines, merely by setting the parameter `shrink_polygons=True`.
+However, you can also run `ocrd-tesserocr-segment*` and `ocrd-tesserocr-recognize` with `shrink_polygons=True` to get **polygons** by post-processing each segment, shrinking to the convex hull of all its symbol outlines.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The text region `@type`s detected are (from Tesseract's [PolyBlockType](https://
 
 If you are unhappy with these choices, consider post-processing with a dedicated custom processor in Python, or by modifying the PAGE files directly (e.g. `xmlstarlet ed --inplace -u '//pc:TextRegion/@type[.="floating"]' -v paragraph filegrp/*.xml`).
 
-All segmentation is currently done as **bounding boxes** only, i.e. without precise polygonal outlines. For dense page layouts this means that neighbouring regions and neighbouring text lines may overlap a lot. If this is a problem for your workflow, try post-processing like so:
+All segmentation is currently done as **bounding boxes** only by default, i.e. without precise polygonal outlines. For dense page layouts this means that neighbouring regions and neighbouring text lines may overlap a lot. If this is a problem for your workflow, try post-processing like so:
 - after line segmentation: use `ocrd-cis-ocropy-resegment` for polygonalization, or `ocrd-cis-ocropy-clip` on the line level
 - after region segmentation: use `ocrd-segment-repair` with `plausibilize` (and `sanitize` after line segmentation)
 
@@ -132,6 +132,8 @@ It also means that Tesseract should be allowed to segment across multiple hierar
 - prefer `ocrd-tesserocr-recognize` with `segmentation_level=region` over `ocrd-tesserocr-segment` followed by `ocrd-tesserocr-recognize`, if you want to do all in one with Tesseract,
 - prefer `ocrd-tesserocr-recognize` with `segmentation_level=line` over `ocrd-tesserocr-segment-line` followed by `ocrd-tesserocr-recognize`, if you want to do everything but region segmentation with Tesseract,
 - prefer `ocrd-tesserocr-segment` over `ocrd-tesserocr-segment-region` followed by (`ocrd-tesserocr-segment-table` and) `ocrd-tesserocr-segment-line`, if you want to do everything but recognition with Tesseract.
+
+If you do allow segmentation across multiple levels, e.g. by using `ocrd-tesserocr-segment` or `ocrd-tesserocr-recognize` with `segmentation_level` higher than `textequiv_level`, then you can also post-process to shrink parents to **polygons** by their constituent outlines, merely by setting the parameter `shrink_polygons=True`.
 
 ## Testing
 

--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -130,7 +130,7 @@
         "shrink_polygons": {
           "type": "boolean",
           "default": false,
-          "description": "When detecting any segments, annotate polygon coordinates instead of bounding box rectangles by projecting the convex hull of their constituents. (From textequiv_level up to segmentation_level.)"
+          "description": "When detecting any segments, annotate polygon coordinates instead of bounding box rectangles by projecting the convex hull of all symbols."
         },
         "block_polygons": {
           "type": "boolean",
@@ -199,6 +199,11 @@
           "description": "extend detected region rectangles by this many (true) pixels",
           "default": 4
         },
+        "shrink_polygons": {
+          "type": "boolean",
+          "default": false,
+          "description": "annotate polygon coordinates instead of bounding box rectangles by projecting the convex hull of all symbols"
+        },
         "block_polygons": {
           "type": "boolean",
           "default": false,
@@ -247,6 +252,11 @@
           "description": "extend detected region rectangles by this many (true) pixels",
           "default": 0
         },
+        "shrink_polygons": {
+          "type": "boolean",
+          "default": false,
+          "description": "annotate polygon coordinates instead of bounding box rectangles by projecting the convex hull of all symbols"
+        },
         "crop_polygons": {
           "type": "boolean",
           "default": false,
@@ -287,6 +297,17 @@
           "type": "boolean",
           "default": true,
           "description": "Remove existing layout and text annotation below the TableRegion level (otherwise skip table; no incremental annotation yet)."
+        },
+        "padding": {
+          "type": "number",
+          "format": "integer",
+          "description": "extend detected cell rectangles by this many (true) pixels",
+          "default": 0
+        },
+        "shrink_polygons": {
+          "type": "boolean",
+          "default": false,
+          "description": "annotate polygon coordinates instead of bounding box rectangles by projecting the convex hull of all symbols"
         }
       }
      },
@@ -313,6 +334,17 @@
           "type": "boolean",
           "default": true,
           "description": "Remove existing layout and text annotation below the TextRegion level (otherwise skip region; no incremental annotation yet)."
+        },
+        "padding": {
+          "type": "number",
+          "format": "integer",
+          "description": "extend detected line rectangles by this many (true) pixels",
+          "default": 0
+        },
+        "shrink_polygons": {
+          "type": "boolean",
+          "default": false,
+          "description": "annotate polygon coordinates instead of bounding box rectangles by projecting the convex hull of all symbols"
         }
       }
     },
@@ -339,6 +371,17 @@
           "type": "boolean",
           "default": true,
           "description": "Remove existing layout and text annotation below the TextLine level (otherwise skip line; no incremental annotation yet)."
+        },
+        "padding": {
+          "type": "number",
+          "format": "integer",
+          "description": "extend detected cell rectangles by this many (true) pixels",
+          "default": 0
+        },
+        "shrink_polygons": {
+          "type": "boolean",
+          "default": false,
+          "description": "annotate polygon coordinates instead of bounding box rectangles by projecting the convex hull of all symbols"
         }
       }
     },

--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -127,10 +127,15 @@
           "default": true,
           "description": "If ``textequiv_level`` is not none, but a segment already contains TextEquivs, remove them and replace with recognised text. Otherwise add new text as alternative. (Only the first entry is projected upwards.)"
         },
+        "shrink_polygons": {
+          "type": "boolean",
+          "default": false,
+          "description": "When detecting any segments, annotate polygon coordinates instead of bounding box rectangles by projecting the convex hull of their constituents. (From textequiv_level up to segmentation_level.)"
+        },
         "block_polygons": {
           "type": "boolean",
           "default": false,
-          "description": "When detecting regions, annotate polygon coordinates instead of bounding box rectangles."
+          "description": "When detecting regions, annotate polygon coordinates instead of bounding box rectangles by querying Tesseract accordingly."
         },
         "find_tables": {
           "type": "boolean",

--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -167,6 +167,11 @@
           "default": "",
           "description": "When recognizing text, enumeration of character hypotheses (from the model) to allow inclusively."
         },
+        "tesseract_parameters": {
+          "type": "object",
+          "default": {},
+          "description": "Dictionary of additional Tesseract runtime variables (cf. tesseract --print-parameters), string values."
+        },
         "model": {
           "type": "string",
           "description": "The tessdata text recognition model to apply (an ISO 639-3 language specification or some other basename, e.g. deu-frak or Fraktur)."

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -424,7 +424,7 @@ class TesserocrRecognize(Processor):
                     PT.EQUATION,
                     PT.TABLE] and (
                         xywh['w'] < 20 / 300.0*(dpi or 300) or
-                        xywh['h'] < 30 / 300.0*(dpi or 300)):
+                        xywh['h'] < 10 / 300.0*(dpi or 300)):
                 self.logger.info('Ignoring too small region: %s', points)
                 continue
             region_image_bin = it.GetBinaryImage(RIL.BLOCK)

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -420,7 +420,7 @@ class TesserocrRecognize(Processor):
             # (probably a bug in Tesseract itself, cf. tesseract#2826):
             if self.parameter['block_polygons']:
                 polygon = it.BlockPolygon()
-            elif self.parameter['shrink_polygons']:
+            elif self.parameter['shrink_polygons'] and not it.Empty(RIL.SYMBOL):
                 polygon = join_polygons([polygon_from_x0y0x1y1(
                     symbol.BoundingBox(RIL.SYMBOL, padding=self.parameter['padding']))
                                          for symbol in iterate_level(it, RIL.SYMBOL, parent=RIL.BLOCK)])
@@ -556,7 +556,7 @@ class TesserocrRecognize(Processor):
             ril = RIL.PARA # for "cells" in PT.TABLE block
         for index, it in enumerate(iterate_level(result_it, ril)):
             bbox = it.BoundingBox(ril, padding=self.parameter['padding'])
-            if self.parameter['shrink_polygons']:
+            if self.parameter['shrink_polygons'] and not it.Empty(RIL.SYMBOL):
                 polygon = join_polygons([polygon_from_x0y0x1y1(
                     symbol.BoundingBox(RIL.SYMBOL, padding=self.parameter['padding']))
                                          for symbol in iterate_level(it, RIL.SYMBOL, parent=ril)])
@@ -612,7 +612,7 @@ class TesserocrRecognize(Processor):
             return
         for index, it in enumerate(iterate_level(result_it, RIL.TEXTLINE, parent=parent_ril)):
             bbox = it.BoundingBox(RIL.TEXTLINE, padding=self.parameter['padding'])
-            if self.parameter['shrink_polygons']:
+            if self.parameter['shrink_polygons'] and not it.Empty(RIL.SYMBOL):
                 polygon = join_polygons([polygon_from_x0y0x1y1(
                     symbol.BoundingBox(RIL.SYMBOL, padding=self.parameter['padding']))
                                          for symbol in iterate_level(it, RIL.SYMBOL, parent=RIL.TEXTLINE)])
@@ -644,7 +644,7 @@ class TesserocrRecognize(Processor):
     def _process_words_in_line(self, result_it, line, coords):
         for index, it in enumerate(iterate_level(result_it, RIL.WORD)):
             bbox = it.BoundingBox(RIL.WORD, padding=self.parameter['padding'])
-            if self.parameter['shrink_polygons']:
+            if self.parameter['shrink_polygons'] and not it.Empty(RIL.SYMBOL):
                 polygon = join_polygons([polygon_from_x0y0x1y1(
                     symbol.BoundingBox(RIL.SYMBOL, padding=self.parameter['padding']))
                                          for symbol in iterate_level(it, RIL.SYMBOL, parent=RIL.WORD)])

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -11,6 +11,7 @@ from tesserocr import (
     Orientation,
     WritingDirection,
     TextlineOrder,
+    tesseract_version,
     PyTessBaseAPI, get_languages as get_languages_)
 
 from ocrd_utils import (
@@ -72,7 +73,7 @@ class TesserocrRecognize(Processor):
 
     def __init__(self, *args, **kwargs):
         kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
-        kwargs['version'] = OCRD_TOOL['version']
+        kwargs['version'] = OCRD_TOOL['version'] + ' (' + tesseract_version().split('\n')[0] + ')'
         super(TesserocrRecognize, self).__init__(*args, **kwargs)
         
         if hasattr(self, 'workspace'):

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -190,6 +190,9 @@ class TesserocrRecognize(Processor):
         single-line text blocks in no particular order (Tesseract's page segmentation
         mode ``SPARSE_TEXT``).
         
+        If ``tesseract_parameters`` is given, setup each of its key-value pairs as
+        run-time parameters in Tesseract.
+        
         Finally, produce new output files by serialising the resulting hierarchy.
         """
         self.logger.debug("TESSDATA: %s, installed Tesseract models: %s", *get_languages())
@@ -267,6 +270,9 @@ class TesserocrRecognize(Processor):
             # lstm_use_matrix 1
             # user_words_file
             # user_patterns_file
+            tesseract_params = self.parameter['tesseract_parameters']
+            for variable in tesseract_params:
+                tessapi.SetVariable(variable, tesseract_params[variable])
             for (n, input_file) in enumerate(self.input_files):
                 page_id = input_file.pageId or input_file.ID
                 self.logger.info("INPUT FILE %i / %s", n, page_id)

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -492,7 +492,7 @@ class TesserocrRecognize(Processor):
                     region.set_type(TextTypeSimpleType.CAPTION)
                 page.add_TextRegion(region)
                 og.add_RegionRefIndexed(RegionRefIndexedType(regionRef=ID, index=index))
-                if self.parameter['textequiv_level'] != 'region':
+                if self.parameter['textequiv_level'] not in ['region', 'cell']:
                     self._process_lines_in_region(it, region, page_coords)
                 elif self.parameter.get('model', ''):
                     region.add_TextEquiv(TextEquivType(

--- a/ocrd_tesserocr/segment.py
+++ b/ocrd_tesserocr/segment.py
@@ -45,6 +45,12 @@ class TesserocrSegment(Processor):
         (This is more precise, but due to some path representation errors does
         not always yield accurate/valid polygons.)
         
+        If ``shrink_polygons``, then query Tesseract for all symbols/glyphs
+        of each segment and calculate the convex hull for them.
+        Annotate the resulting polygon instead of the coarse bounding box.
+        (This is more precise and helps avoid overlaps between neighbours, especially
+        when not segmenting all levels at once.)
+        
         If ``sparse_text``, then attempt to find single-line text blocks only,
         in no particular order.
         

--- a/ocrd_tesserocr/segment.py
+++ b/ocrd_tesserocr/segment.py
@@ -21,6 +21,7 @@ class TesserocrSegment(Processor):
             recognize_kwargs.pop('show_help', None)
             recognize_kwargs.pop('show_version', None)
             recognize_kwargs['parameter'] = self.parameter
+            recognize_kwargs['parameter']['overwrite_segments'] = True
             recognize_kwargs['parameter']['segmentation_level'] = "region"
             recognize_kwargs['parameter']['textequiv_level'] = "none"
             self.recognizer = TesserocrRecognize(self.workspace, **recognize_kwargs)

--- a/ocrd_tesserocr/segment_line.py
+++ b/ocrd_tesserocr/segment_line.py
@@ -24,7 +24,7 @@ class TesserocrSegmentLine(Processor):
             recognize_kwargs['parameter']['overwrite_segments'] = self.parameter['overwrite_lines']
             del recognize_kwargs['parameter']['overwrite_lines']
             recognize_kwargs['parameter']['segmentation_level'] = "line"
-            recognize_kwargs['parameter']['textequiv_level'] = "none"
+            recognize_kwargs['parameter']['textequiv_level'] = "line"
             self.recognizer = TesserocrRecognize(self.workspace, **recognize_kwargs)
             self.recognizer.logger = getLogger('processor.TesserocrSegmentLine')
 

--- a/ocrd_tesserocr/segment_line.py
+++ b/ocrd_tesserocr/segment_line.py
@@ -39,6 +39,12 @@ class TesserocrSegmentLine(Processor):
         Set up Tesseract to detect lines, and add each one to the region
         at the detected coordinates.
         
+        If ``shrink_polygons``, then during segmentation (on any level), query Tesseract
+        for all symbols/glyphs of each segment and calculate the convex hull for them.
+        Annotate the resulting polygon instead of the coarse bounding box.
+        (This is more precise and helps avoid overlaps between neighbours, especially
+        when not segmenting all levels at once.)
+        
         Produce a new output file by serialising the resulting hierarchy.
         """
         return self.recognizer.process()

--- a/ocrd_tesserocr/segment_region.py
+++ b/ocrd_tesserocr/segment_region.py
@@ -24,11 +24,11 @@ class TesserocrSegmentRegion(Processor):
             recognize_kwargs['parameter']['overwrite_segments'] = self.parameter['overwrite_regions']
             del recognize_kwargs['parameter']['overwrite_regions']
             recognize_kwargs['parameter']['segmentation_level'] = "region"
-            recognize_kwargs['parameter']['textequiv_level'] = "none"
+            recognize_kwargs['parameter']['textequiv_level'] = "region"
             recognize_kwargs['parameter']['block_polygons'] = self.parameter['crop_polygons']
             del recognize_kwargs['parameter']['crop_polygons']
             self.recognizer = TesserocrRecognize(self.workspace, **recognize_kwargs)
-            self.recognizer.logger = getLogger('processor.TesserocrSegmentWord')
+            self.recognizer.logger = getLogger('processor.TesserocrSegmentRegion')
 
     def process(self):
         """Performs region segmentation with Tesseract on the workspace.

--- a/ocrd_tesserocr/segment_region.py
+++ b/ocrd_tesserocr/segment_region.py
@@ -47,6 +47,12 @@ class TesserocrSegmentRegion(Processor):
         but due to some path representation errors does not always yield
         accurate/valid polygons.)
         
+        If ``shrink_polygons``, then query Tesseract for all symbols/glyphs
+        of each segment and calculate the convex hull for them.
+        Annotate the resulting polygon instead of the coarse bounding box.
+        (This is more precise and helps avoid overlaps between neighbours, especially
+        when not segmenting all levels at once.)
+        
         Produce a new output file by serialising the resulting hierarchy.
         """
         return self.recognizer.process()

--- a/ocrd_tesserocr/segment_table.py
+++ b/ocrd_tesserocr/segment_table.py
@@ -24,7 +24,7 @@ class TesserocrSegmentTable(Processor):
             recognize_kwargs['parameter']['overwrite_segments'] = self.parameter['overwrite_cells']
             del recognize_kwargs['parameter']['overwrite_regions']
             recognize_kwargs['parameter']['segmentation_level'] = "cell"
-            recognize_kwargs['parameter']['textequiv_level'] = "none"
+            recognize_kwargs['parameter']['textequiv_level'] = "cell"
             self.recognizer = TesserocrRecognize(self.workspace, **recognize_kwargs)
             self.recognizer.logger = getLogger('processor.TesserocrSegmentTable')
 

--- a/ocrd_tesserocr/segment_word.py
+++ b/ocrd_tesserocr/segment_word.py
@@ -38,6 +38,12 @@ class TesserocrSegmentWord(Processor):
         Set up Tesseract to detect words, and add each one to the line
         at the detected coordinates.
         
+        If ``shrink_polygons``, then during segmentation (on any level), query Tesseract
+        for all symbols/glyphs of each segment and calculate the convex hull for them.
+        Annotate the resulting polygon instead of the coarse bounding box.
+        (This is more precise and helps avoid overlaps between neighbours, especially
+        when not segmenting all levels at once.)
+        
         Produce a new output file by serialising the resulting hierarchy.
         """
         return self.recognizer.process()

--- a/ocrd_tesserocr/segment_word.py
+++ b/ocrd_tesserocr/segment_word.py
@@ -24,7 +24,7 @@ class TesserocrSegmentWord(Processor):
             recognize_kwargs['parameter']['overwrite_segments'] = self.parameter['overwrite_words']
             del recognize_kwargs['parameter']['overwrite_words']
             recognize_kwargs['parameter']['segmentation_level'] = "word"
-            recognize_kwargs['parameter']['textequiv_level'] = "none"
+            recognize_kwargs['parameter']['textequiv_level'] = "word"
             self.recognizer = TesserocrRecognize(self.workspace, **recognize_kwargs)
             self.recognizer.logger = getLogger('processor.TesserocrSegmentWord')
 


### PR DESCRIPTION
This implements an idea I had long time ago to at least get _some_ polygons out of Tesseract, reducing the large overlap between bounding boxes. If you set `shrink_polygons`, then `segment*` and `recognize` will post-process their segmentation by projecting convex hull upwards from `textequiv_level` to `segmentation_level`.

For example, `ocrd-tesserocr-segment` now yields:
![tesserocr-polygons](https://user-images.githubusercontent.com/38561704/101240127-98954300-36ed-11eb-82fa-26f22ffe18c1.png)
