### PR TITLE
adjust output fileGrp name

### DIFF
--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -45,7 +45,7 @@
         "OCR-D-OCR"
       ],
       "output_file_grp": [
-        "OCR-D-OCR-STYLE"
+        "OCR-D-OCR-FONTSTYLE"
       ],
       "steps": ["recognition/font-identification"],
       "parameters": {


### PR DESCRIPTION
`OCR-D-OCR-FONTSTYLE` seems more specific than `OCR-D-OCR-STYLE` (to me at least). `TEXTSTYLE` or `FONTSHAPE` would also be fine. I understand this is probably just cosmetics, so treat this as a suggestion ;)