### PR TITLE
log models with .traineddata extension as error

### DIFF
--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -207,6 +207,9 @@ class TesserocrRecognize(Processor):
         if 'model' in self.parameter:
             model = self.parameter['model']
             for sub_model in model.split('+'):
+                if sub_model.endswith('.traineddata'):
+                    self.logger.warning("Model '%s' has a  .traineddata extension, removing. Please use model names without .traineddata extension" % sub_model)
+                    sub_model = sub_model.replace('.traineddata', '')
                 if sub_model not in get_languages()[1]:
                     raise Exception("configured model " + sub_model + " is not installed")
                 self.logger.info("Using model '%s' in %s for recognition at the %s level",


### PR DESCRIPTION
The problem is that `resmgr` doesn't know the `parameter_usage` of unregistered resources, since they are resource-specific, not processor-specific:

```
$ ocrd resmgr download -n ocrd-tesserocr-recognize https://github.com/tesseract-ocr/tessdata/raw/master/fin.traineddata
[...]
INFO ocrd.cli.resmgr - Use in parameters as 'fin.traineddata'
```

But that is the wrong parameter usage.

Remedies:

  1. Make `parameter_usage` processor-specific. That requires changing the data model which I am not a fan of.
  2. Warn users in tesserocr-recognize that they have a likely spurious `.traineddata` extension (what this PR currently does)
  3. Chop of the `.traineddata` form any (sub-)models in tesserocr.

I don't think there should ever be a model named `foo.traineddata.traineddata`, so I think 3 would be a valid workaround.