### PR TITLE
Skip recognition when text exists and not `overwrite_text`

### DIFF
--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -172,6 +172,12 @@
           "default": {},
           "description": "Dictionary of additional Tesseract runtime variables (cf. tesseract --print-parameters), string values."
         },
+        "oem": {
+          "type": "string",
+          "enum": ["TESSERACT_ONLY", "LSTM_ONLY", "TESSERACT_LSTM_COMBINED", "DEFAULT"],
+          "default": "DEFAULT",
+          "description": "Tesseract OCR engine mode to use:\n* Run Tesseract only - fastest,\n* Run just the LSTM line recognizer. (>=v4.00),\n*Run the LSTM recognizer, but allow fallback to Tesseract when things get difficult. (>=v4.00),\n*Run both and combine results - best accuracy."
+        },
         "model": {
           "type": "string",
           "description": "The tessdata text recognition model to apply (an ISO 639-3 language specification or some other basename, e.g. deu-frak or Fraktur)."

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -7,7 +7,7 @@ from shapely.geometry import Polygon, asPolygon
 from shapely.ops import unary_union
 
 from tesserocr import (
-    RIL, PSM, PT,
+    RIL, PSM, PT, OEM,
     Orientation,
     WritingDirection,
     TextlineOrder,
@@ -212,7 +212,9 @@ class TesserocrRecognize(Processor):
                 self.logger.info("Using model '%s' in %s for recognition at the %s level",
                                  model, get_languages()[0], outlevel)
         
-        with PyTessBaseAPI(path=TESSDATA_PREFIX, lang=model) as tessapi:
+        with PyTessBaseAPI(path=TESSDATA_PREFIX,
+                           lang=model,
+                           oem=getattr(OEM, self.parameter['oem'])) as tessapi:
             if outlevel == 'glyph':
                 # populate GetChoiceIterator() with LSTM models, too:
                 tessapi.SetVariable("lstm_choice_mode", "2") # aggregate symbols


### PR DESCRIPTION
This redefines the meaning of `overwrite_text`: If text exists for a segment, then skip it (instead of always running the recognition and just appending new results).