### PR TITLE
OSD on line level, recognition by loading script or lang from PAGE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [0.13.1] - 2021-06-30
+
+Fixed:
+
+  * deps-ubuntu/Docker: adapt to resmgr location mechanism, link to PPA models
+  * recognize: :bug: skip detected segments if polygon cannot be made valid
+
+Changed:
+
+  * deskew: add line-level operation for script detection
+  * recognize: query more choices for textequiv_level=glyph if available
+  * recognize: :fire: reset Tesseract API when applying model/param settings per segment
+  * recognize: :eyes: allow configuring Tesseract parameters per segment via XPath queries
+  * recognize: :eyes: allow selecting recognition model per segment via XPath queries
+  * recognize: :eyes: allow selecting recognition model automatically via confidence
+
 ## [0.13.0] - 2021-06-30
 
 Changed:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@ MAINTAINER OCR-D
 ENV DEBIAN_FRONTEND noninteractive
 ENV PYTHONIOENCODING utf8
 
+# avoid HOME/.local/share (hard to predict USER here)
+# so let XDG_DATA_HOME coincide with fixed system location
+# (can still be overridden by derived stages)
+ENV XDG_DATA_HOME /usr/local/share
+
 WORKDIR /build-ocrd
 COPY setup.py .
 COPY ocrd_tesserocr/ocrd-tool.json .
@@ -14,8 +19,11 @@ COPY Makefile .
 RUN make deps-ubuntu && \
     apt-get install -y --no-install-recommends \
     g++ \
-    tesseract-ocr-script-frak \
-    tesseract-ocr-deu \
     && make deps install \
     && rm -rf /build-ocrd \
     && apt-get -y remove --auto-remove g++ libtesseract-dev make
+RUN ocrd resmgr download ocrd-tesserocr-recognize Fraktur.traineddata
+RUN ocrd resmgr download ocrd-tesserocr-recognize deu.traineddata
+
+WORKDIR /data
+VOLUME /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM ocrd/core
-MAINTAINER OCR-D
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL \
+    maintainer="https://ocr-d.de/kontakt" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url="https://github.com/OCR-D/ocrd_tesserocr" \
+    org.label-schema.build-date=$BUILD_DATE
+
 ENV DEBIAN_FRONTEND noninteractive
 ENV PYTHONIOENCODING utf8
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ PYTEST_ARGS =
 # Docker container tag
 DOCKER_TAG = 'ocrd/tesserocr'
 
+# search path for recognition models
+TESSDATA_PREFIX ?= $(or $(XDG_DATA_HOME),$(HOME)/.local/share)/ocrd-resources
+
 # BEGIN-EVAL makefile-parser --make-help Makefile
 
 help:
@@ -38,8 +41,9 @@ help:
 	@echo ""
 	@echo "  Variables"
 	@echo ""
-	@echo "    PYTEST_ARGS  pytest args. Set to '-s' to see log output during test execution, '--verbose' to see individual tests. Default: '$(PYTEST_ARGS)'"
-	@echo "    DOCKER_TAG   Docker container tag"
+	@echo "    PYTEST_ARGS     pytest args. Set to '-s' to see log output during test execution, '--verbose' to see individual tests. Default: '$(PYTEST_ARGS)'"
+	@echo "    DOCKER_TAG      Docker container tag"
+	@echo "    TESSDATA_PREFIX search path for recognition models"
 
 # END-EVAL
 
@@ -62,6 +66,8 @@ deps-ubuntu:
 		libleptonica-dev \
 		tesseract-ocr-eng \
 		tesseract-ocr
+	mkdir -p $(TESSDATA_PREFIX)
+	ln -rs -t $(TESSDATA_PREFIX) /usr/share/tesseract-ocr/4.00/tessdata/*.traineddata
 
 # Install Python deps for install via pip
 deps:
@@ -99,6 +105,7 @@ test-cli: test/assets
 	$(PIP) install -e .
 	rm -rfv test/workspace
 	cp -rv test/assets/kant_aufklaerung_1784 test/workspace
+	ocrd resmgr download ocrd-tesserocr-recognize eng.traineddata
 	ocrd resmgr download ocrd-tesserocr-recognize deu.traineddata
 	cd test/workspace/data && \
 		ocrd-tesserocr-segment-region -l DEBUG -I OCR-D-IMG -O OCR-D-SEG-REGION && \

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PYTEST_ARGS =
 DOCKER_TAG = 'ocrd/tesserocr'
 
 # search path for recognition models
-TESSDATA_PREFIX ?= $(or $(XDG_DATA_HOME),$(HOME)/.local/share)/ocrd-resources
+TESSDATA_PREFIX ?= $(or $(XDG_DATA_HOME),$(HOME)/.local/share)/ocrd-resources/ocrd-tesserocr-recognize
 
 # BEGIN-EVAL makefile-parser --make-help Makefile
 

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,10 @@ deps-test:
 
 # Build docker image
 docker:
-	docker build -t $(DOCKER_TAG) .
+	docker build \
+	--build-arg VCS_REF=$$(git rev-parse --short HEAD) \
+	--build-arg BUILD_DATE=$$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
+	-t $(DOCKER_TAG) .
 
 # Install this package
 install: deps

--- a/README.md
+++ b/README.md
@@ -17,13 +17,23 @@ Most processors can operate on different levels of the PAGE hierarchy, depending
 
 ## Installation
 
-### Required ubuntu packages:
+### With docker
 
-- Tesseract headers (`libtesseract-dev`)
-- Some Tesseract language models (`tesseract-ocr-{eng,deu,frk,...}` or script models (`tesseract-ocr-script-{latn,frak,...}`); or better yet custom [trained](https://github.com/tesseract-ocr/tesstrain) models
-- Leptonica headers (`libleptonica-dev`)
+This is the best option if you want to run the software in a container.
 
-### From PyPI
+You need to have [Docker](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
+
+
+    docker pull ocrd/tesserocr
+
+
+To run with docker:
+
+
+    docker run -v path/to/workspaces:/data ocrd/tesserocr ocrd-tesserocrd-crop ...
+
+
+### From PyPI and PPA
 
 This is the best option if you want to use the stable, released version.
 
@@ -44,40 +54,41 @@ sudo apt-get update
 ---
 
 ```sh
-sudo apt-get install git python3 python3-pip libtesseract-dev libleptonica-dev tesseract-ocr-eng tesseract-ocr wget
+sudo apt-get install python3 python3-pip libtesseract-dev libleptonica-dev tesseract-ocr wget
 pip install ocrd_tesserocr
 ```
 
-### With docker
+### From git
 
-This is the best option if you want to run the software in a container.
-
-You need to have [Docker](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
-
-```sh
-docker pull ocrd/tesserocr
-```
-
-To run with docker:
-
-```
-docker run -v path/to/workspaces:/data ocrd/tesserocr ocrd-tesserocrd-crop ...
-```
-
-
-### From git 
-
-This is the best option if you want to change the source code or install the latest, unpublished changes.
+Use this option if you want to change the source code or install the latest, unpublished changes.
 
 We strongly recommend to use [venv](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/).
 
 ```sh
 git clone https://github.com/OCR-D/ocrd_tesserocr
 cd ocrd_tesserocr
-sudo make deps-ubuntu # or manually with apt-get
+# install Tesseract:
+sudo make deps-ubuntu # or manually from git or via ocrd_all
+# install tesserocr and ocrd_tesserocr:
 make deps        # or pip install -r requirements
 make install     # or pip install .
 ```
+
+## Models
+
+Tesseract comes with synthetically trained models for languages (`tesseract-ocr-{eng,deu,frk,...}` or scripts (`tesseract-ocr-script-{latn,frak,...}`). In addition, various models [trained](https://github.com/tesseract-ocr/tesstrain) on scan data are available from the community.
+
+Note that since all OCR-D processors must resolve file/data resources in a [standardized way](https://ocr-d.de/en/spec/cli#processor-resources), `ocrd-tesserocr-recognize` expects the recognition models to be installed in `$XDG_DATA_HOME/ocrd-resources/ocrd-tesserocr-recognize` (where, usually, `$XDG_DATA_HOME=$HOME/.local/share`). This is the default **resource location** used by `ocrd resmgr`, which you can use to download and list models:
+
+    ocrd resmgr --help
+
+(However, for backwards compatibility, this can be overriden by defining `$TESSDATA_PREFIX` in the environment. In this case users must install models manually – by linking/copying or downloading them into that directory. The same is true for the non-default location used by the system packages `tesseract-ocr-*`, which is usually `/usr/share/tesseract-ocr/4.00/tessdata`.)
+
+Cf. [OCR-D model guide](https://ocr-d.de/en/models).
+
+Models always use the filename suffix `.traineddata`, but are just loaded by their basename. You will need **at least** `eng` and `osd` (even for segmentation and deskewing), probably also `Latin` and `Fraktur` etc.
+
+As of v0.13.1, you can configure `ocrd-tesserocr-recognize` to select models **dynamically** segment by segment, either via custom conditions on the PAGE-XML annotation (presented as XPath rules), or by automatically choosing the model with highest confidence.
 
 ## Usage
 

--- a/ocrd_tesserocr/deskew.py
+++ b/ocrd_tesserocr/deskew.py
@@ -22,7 +22,7 @@ from ocrd_utils import (
 from ocrd_modelfactory import page_from_file
 from ocrd_models.ocrd_page import (
     AlternativeImageType,
-    TextRegionType, PageType,
+    TextLineType, TextRegionType, PageType,
     to_xml
 )
 from ocrd import Processor
@@ -67,6 +67,8 @@ class TesserocrDeskew(Processor):
                 oem=OEM.TESSERACT_LSTM_COMBINED, # legacy required for OSD!
                 psm=PSM.AUTO_OSD
         ) as tessapi:
+            if oplevel == 'line':
+                tessapi.SetVariable("min_characters_to_try", "15")
             for n, input_file in enumerate(self.input_files):
                 file_id = make_file_id(input_file, self.output_file_grp)
                 page_id = input_file.pageId or input_file.ID
@@ -103,7 +105,7 @@ class TesserocrDeskew(Processor):
                                           "page '%s'" % page_id, input_file.pageId,
                                           file_id)
                 else:
-                    regions = page.get_TextRegion() + page.get_TableRegion()
+                    regions = page.get_AllRegions(classes=['Text', 'Table'])
                     if not regions:
                         LOG.warning("Page '%s' contains no text regions", page_id)
                     for region in regions:
@@ -113,9 +115,20 @@ class TesserocrDeskew(Processor):
                             # (we will overwrite @orientation anyway,)
                             # abort if no such image can be produced:
                             feature_filter='deskewed')
-                        self._process_segment(tessapi, region, region_image, region_xywh,
-                                              "region '%s'" % region.id, input_file.pageId,
-                                              file_id + '_' + region.id)
+                        if oplevel == 'region':
+                            self._process_segment(tessapi, region, region_image, region_xywh,
+                                                  "region '%s'" % region.id, input_file.pageId,
+                                                  file_id + '_' + region.id)
+                        elif isinstance(region, TextRegionType):
+                            lines = region.get_TextLine()
+                            if not lines:
+                                LOG.warning("Page '%s' region '%s' contains no lines", page_id, region.id)
+                            for line in lines:
+                                line_image, line_xywh = self.workspace.image_from_segment(
+                                    line, region_image, region_xywh)
+                                self._process_segment(tessapi, line, line_image, line_xywh,
+                                                      "line '%s'" % line.id, input_file.pageId,
+                                                      file_id + '_' + region.id + '_' + line.id)
                 
                 self.workspace.add_file(
                     ID=file_id,
@@ -158,7 +171,7 @@ class TesserocrDeskew(Processor):
             else:
                 LOG.info('applying OSD script result "%s" with high confidence %.0f in %s',
                          osr['script_name'], osr['script_conf'], where)
-                if isinstance(segment, (TextRegionType, PageType)):
+                if isinstance(segment, (TextLineType, TextRegionType, PageType)):
                     segment.set_primaryScript({
                         "Arabic": "Arab - Arabic",
                         "Armenian": "Armn - Armenian",
@@ -204,6 +217,8 @@ class TesserocrDeskew(Processor):
                     }.get(osr['script_name'], "Latn - Latin"))
         else:
             LOG.warning('no OSD result in %s', where)
+        if isinstance(segment, TextLineType):
+            return
         #
         # orientation/skew
         #

--- a/ocrd_tesserocr/deskew.py
+++ b/ocrd_tesserocr/deskew.py
@@ -262,6 +262,7 @@ class TesserocrDeskew(Processor):
             # This effectively ignores Orientation from AnalyseLayout,
             # because it is usually wrong when it deviates from OSD results.
             # (We do keep deskew_angle, though – see below.)
+            # FIXME: revisit that decision after trying with api.set_min_orientation_margin
             LOG.warning('inconsistent angles from layout analysis (%d) and orientation detection (%d) in %s',
                         angle2, angle, where)
         # annotate result:

--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -172,6 +172,16 @@
           "default": {},
           "description": "Dictionary of additional Tesseract runtime variables (cf. tesseract --print-parameters), string values."
         },
+	"script_model": {
+	  "type": "object",
+	  "default": {},
+	  "description": "Prefer models mapped according to annotated @primaryScript (where available). If no mappings match (or under the default empty parameter), then fall back to `model`. (Example: {'Latn - Latin': 'lat+Latin', 'Grek - Greek': 'grc+ell'})"
+	},
+	"lang_model": {
+	  "type": "object",
+	  "default": {},
+	  "description": "Prefer models mapped according to annotated @primaryLanguage (where available). If no mappings match (or under the default empty parameter), then fall back to `model`. (Example: {'Latin': 'lat+Latin', 'Greek': 'grc+ell', 'German': 'deu+frk'})"
+	},
         "model": {
           "type": "string",
           "description": "The tessdata text recognition model to apply (an ISO 639-3 language specification or some other basename, e.g. deu-frak or Fraktur)."

--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -182,6 +182,11 @@
 	  "default": {},
 	  "description": "Prefer models mapped according to annotated @primaryLanguage (where available). If no mappings match (or under the default empty parameter), then fall back to `model`. (Example: {'Latin': 'lat+Latin', 'Greek': 'grc+ell', 'German': 'deu+frk'})"
 	},
+	"auto_model": {
+	  "type": "boolean",
+	  "default": false,
+	  "description": "Prefer models performing best (by confidence) per segment (if multiple given in `model`). Repeats the OCR of the best model once (i.e. slower). (Use if you do not trust script/language detection.)"
+	},
         "model": {
           "type": "string",
           "description": "The tessdata text recognition model to apply (an ISO 639-3 language specification or some other basename, e.g. deu-frak or Fraktur)."

--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.13.0",
+  "version": "0.13.1",
   "git_url": "https://github.com/OCR-D/ocrd_tesserocr",
   "dockerhub": "ocrd/tesserocr",
   "tools": {

--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -172,20 +172,20 @@
           "default": {},
           "description": "Dictionary of additional Tesseract runtime variables (cf. tesseract --print-parameters), string values."
         },
-	"script_model": {
+	"xpath_parameters": {
 	  "type": "object",
 	  "default": {},
-	  "description": "Prefer models mapped according to annotated @primaryScript (where available). If no mappings match (or under the default empty parameter), then fall back to `model`. (Example: {'Latn - Latin': 'lat+Latin', 'Grek - Greek': 'grc+ell'})"
+	  "description": "Set additional Tesseract runtime variables according to results of XPath queries into the segment. (As a convenience, `@language` and `@script` also match their upwards `@primary*` and `@secondary*` variants where applicable.) (Example: {'ancestor::TextRegion/@type=\"page-number\"': {'char_whitelist': '0123456789-'}, 'contains(@custom,\"ISBN\")': {'char_whitelist': '0123456789-'}})"
 	},
-	"lang_model": {
+	"xpath_model": {
 	  "type": "object",
 	  "default": {},
-	  "description": "Prefer models mapped according to annotated @primaryLanguage (where available). If no mappings match (or under the default empty parameter), then fall back to `model`. (Example: {'Latin': 'lat+Latin', 'Greek': 'grc+ell', 'German': 'deu+frk'})"
+	  "description": "Prefer models mapped according to results of XPath queries into the segment. (As a convenience, `@language` and `@script` also match their upwards `@primary*` and `@secondary*` variants where applicable.) If no queries / mappings match (or under the default empty parameter), then fall back to `model`. If there are multiple matches, combine their results. (Example: {'starts-with(@script,\"Latn\")': 'Latin', 'starts-with(@script,\"Grek\")': 'Greek', '@language=\"Latin\"': 'lat', '@language=\"Greek\"': 'grc+ell', 'ancestor::TextRegion/@type=\"page-number\"': 'eng'})"
 	},
 	"auto_model": {
 	  "type": "boolean",
 	  "default": false,
-	  "description": "Prefer models performing best (by confidence) per segment (if multiple given in `model`). Repeats the OCR of the best model once (i.e. slower). (Use if you do not trust script/language detection.)"
+	  "description": "Prefer models performing best (by confidence) per segment (if multiple given in `model`). Repeats the OCR of the best model once (i.e. slower). (Use as a fallback to xpath_model if you do not trust script/language detection.)"
 	},
         "model": {
           "type": "string",

--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -24,7 +24,7 @@
         },
         "operation_level": {
           "type": "string",
-          "enum": ["page","region"],
+          "enum": ["page","region", "line"],
           "default": "region",
           "description": "PAGE XML hierarchy level to operate on"
         },

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -60,8 +60,8 @@ from .config import TESSDATA_PREFIX, OCRD_TOOL
 
 TOOL = 'ocrd-tesserocr-recognize'
 
-CHOICE_THRESHOLD_NUM = 6 # maximum number of choices to query and annotate
-CHOICE_THRESHOLD_CONF = 0.2 # maximum score drop from best choice to query and annotate
+CHOICE_THRESHOLD_NUM = 16 # maximum number of choices to query and annotate
+CHOICE_THRESHOLD_CONF = 0.001 # maximum score drop from best choice to query and annotate
 
 def get_languages(*args, **kwargs):
     """

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -1342,6 +1342,10 @@ def polygon_for_parent(polygon, parent):
     # (this can happen when shapes valid in floating point are rounded)
     childp = make_valid(childp)
     parentp = make_valid(parentp)
+    if not childp.is_valid:
+        return None
+    if not parentp.is_valid:
+        return None
     # check if clipping is necessary
     if childp.within(parentp):
         return childp.exterior.coords[:-1]


### PR DESCRIPTION
In partial fulfillment of #69 – but I'm afraid osd.traineddata is just too bad for script detection to make this work reliably. Latin vs Cyrillic vs Arabic vs Chinese etc might be easy, but Greek for example does not work on the line level... 

Nevertheless, once we do have script / font detectors on the line level, we could make this work.

- [x] update the PR to the current master
- [x] ~~implement `style_model` (map from `TextStyle` alists to model name)~~
- [x] implement `xpath_model` / `xpath_parameters` (map from PAGE-XML XPath queries to model / variable settings)
- [x] implement `auto_model` (try each loaded model and pick best scoring one)