### PR TITLE
custom --list-resource handler in init, #174

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
 
   build-python36:
     docker:
-      - image: ocrd/core
+      - image: python:3.6
     steps:
       - run: apt-get update && apt-get install -y --no-install-recommends make git curl
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   ubuntu1804:
     docker:
-      - image: ubuntu:18.04
+      - image: ocrd/core
 
 commands:
   install-test-coverage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ commands:
         type: string
     steps:
       - run: apt-get update
-      - run: apt-get install -y software-properties-common
+      - run: apt-get install -y software-properties-common imagemagick
       - run: add-apt-repository -y ppa:deadsnakes/ppa
       - run: apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Europe/Berlin apt-get install -y --no-install-recommends make git curl python<<parameters.python-version>>
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,17 +6,69 @@ jobs:
 
   build-python36:
     docker:
-      - image: python:3.6
+      - image: ubuntu:18.04
     steps:
-      - run: apt-get update && apt-get install -y --no-install-recommends make git curl
+      - run: apt-get update
+      - run: apt-get install -y software-properties-common
+      - run: add-apt-repository -y ppa:deadsnakes/ppa
+      - run: apt-get update && apt-get install -y --no-install-recommends make git curl python3.6
       - checkout
       - run: make deps-ubuntu
-      - run: make install
-      - run: make test-cli
-      - run: make coverage
+      - run: make install PYTHON=python3.6
+      - run: make test-cli PYTHON=python3.6
+      - run: make coverage PYTHON=python3.6
+      - codecov/upload
+
+  build-python37:
+    docker:
+      - image: ubuntu:18.04
+    steps:
+      - run: apt-get update
+      - run: apt-get install -y software-properties-common
+      - run: add-apt-repository -y ppa:deadsnakes/ppa
+      - run: apt-get update && apt-get install -y --no-install-recommends make git curl python3.7
+      - checkout
+      - run: make deps-ubuntu
+      - run: make install PYTHON=python3.7
+      - run: make test-cli PYTHON=python3.7
+      - run: make coverage PYTHON=python3.7
+      - codecov/upload
+
+
+  build-python38:
+    docker:
+      - image: ubuntu:18.04
+    steps:
+      - run: apt-get update
+      - run: apt-get install -y software-properties-common
+      - run: add-apt-repository -y ppa:deadsnakes/ppa
+      - run: apt-get update && apt-get install -y --no-install-recommends make git curl python3.8
+      - checkout
+      - run: make deps-ubuntu
+      - run: make install PYTHON=python3.8
+      - run: make test-cli PYTHON=python3.8
+      - run: make coverage PYTHON=python3.8
+      - codecov/upload
+
+  build-python39:
+    docker:
+      - image: ubuntu:18.04
+    steps:
+      - run: apt-get update
+      - run: apt-get install -y software-properties-common
+      - run: add-apt-repository -y ppa:deadsnakes/ppa
+      - run: apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Europe/Berlin apt-get install -y --no-install-recommends make git curl python3.9
+      - checkout
+      - run: make deps-ubuntu
+      - run: make install PYTHON=python3.9
+      - run: make test-cli PYTHON=python3.9
+      - run: make coverage PYTHON=python3.9
       - codecov/upload
 
 workflows:
   build:
     jobs:
       - build-python36
+      - build-python37
+      - build-python38
+      - build-python39

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,74 +1,49 @@
 version: 2.1
+
 orbs:
   codecov: codecov/codecov@1.0.5
 
+executors:
+  ubuntu1804:
+    docker:
+      - image: ubuntu:18.04
+
+commands:
+  install-test-coverage:
+    parameters:
+      python-version:
+        type: string
+    steps:
+      - run: apt-get update
+      - run: apt-get install -y software-properties-common
+      - run: add-apt-repository -y ppa:deadsnakes/ppa
+      - run: apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Europe/Berlin apt-get install -y --no-install-recommends make git curl python<<parameters.python-version>>
+      - checkout
+      - run: make deps-ubuntu
+      - run: make install PYTHON=python<<parameters.python-version>>
+      - run: make test-cli PYTHON=python<<parameters.python-version>>
+      - run: make coverage PYTHON=python<<parameters.python-version>>
+      - codecov/upload
+
 jobs:
 
-  build-python36:
-    docker:
-      - image: ubuntu:18.04
+  build-python:
+    executor: ubuntu1804
+    parameters:
+      python-version:
+        type: string
     steps:
-      - run: apt-get update
-      - run: apt-get install -y software-properties-common
-      - run: add-apt-repository -y ppa:deadsnakes/ppa
-      - run: apt-get update && apt-get install -y --no-install-recommends make git curl python3.6
-      - checkout
-      - run: make deps-ubuntu
-      - run: make install PYTHON=python3.6
-      - run: make test-cli PYTHON=python3.6
-      - run: make coverage PYTHON=python3.6
-      - codecov/upload
-
-  build-python37:
-    docker:
-      - image: ubuntu:18.04
-    steps:
-      - run: apt-get update
-      - run: apt-get install -y software-properties-common
-      - run: add-apt-repository -y ppa:deadsnakes/ppa
-      - run: apt-get update && apt-get install -y --no-install-recommends make git curl python3.7
-      - checkout
-      - run: make deps-ubuntu
-      - run: make install PYTHON=python3.7
-      - run: make test-cli PYTHON=python3.7
-      - run: make coverage PYTHON=python3.7
-      - codecov/upload
-
-
-  build-python38:
-    docker:
-      - image: ubuntu:18.04
-    steps:
-      - run: apt-get update
-      - run: apt-get install -y software-properties-common
-      - run: add-apt-repository -y ppa:deadsnakes/ppa
-      - run: apt-get update && apt-get install -y --no-install-recommends make git curl python3.8
-      - checkout
-      - run: make deps-ubuntu
-      - run: make install PYTHON=python3.8
-      - run: make test-cli PYTHON=python3.8
-      - run: make coverage PYTHON=python3.8
-      - codecov/upload
-
-  build-python39:
-    docker:
-      - image: ubuntu:18.04
-    steps:
-      - run: apt-get update
-      - run: apt-get install -y software-properties-common
-      - run: add-apt-repository -y ppa:deadsnakes/ppa
-      - run: apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Europe/Berlin apt-get install -y --no-install-recommends make git curl python3.9
-      - checkout
-      - run: make deps-ubuntu
-      - run: make install PYTHON=python3.9
-      - run: make test-cli PYTHON=python3.9
-      - run: make coverage PYTHON=python3.9
-      - codecov/upload
+      - install-test-coverage:
+          python-version: <<parameters.python-version>>
 
 workflows:
   build:
     jobs:
-      - build-python36
-      - build-python37
-      - build-python38
-      - build-python39
+      - build-python:
+          matrix:
+            parameters:
+              python-version:
+                - '3.6'
+                - '3.7'
+                - '3.8'
+                - '3.9'

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ PYTHON = python3
 PIP = pip3
 LOG_LEVEL = INFO
 PYTHONIOENCODING=utf8
+LC_ALL = C.UTF-8
+LANG = C.UTF-8
+export
+
 
 # pytest args. Set to '-s' to see log output during test execution, '--verbose' to see individual tests. Default: '$(PYTEST_ARGS)'
 PYTEST_ARGS =
@@ -53,6 +57,7 @@ help:
 deps-ubuntu:
 	apt-get install -y --no-install-recommends software-properties-common
 	add-apt-repository -y ppa:alex-p/tesseract-ocr
+	apt-get update
 	apt-get install -y \
 		g++ \
 		git \

--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -63,6 +63,8 @@
         },
         "model": {
           "type": "string",
+          "format": "uri",
+          "content-type": "application/octet-stream",
           "default": "osd",
           "description": "tessdata model to apply (an ISO 639-3 language specification or some other basename, e.g. deu-frak or osd); must be an old (pre-LSTM) model"
         }
@@ -180,6 +182,8 @@
         },
         "model": {
           "type": "string",
+          "format": "uri",
+          "content-type": "application/octet-stream",
           "description": "The tessdata text recognition model to apply (an ISO 639-3 language specification or some other basename, e.g. deu-frak or Fraktur)."
         }
       }

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
-import os.path
+from os.path import join
+from sys import exit
+from os import scandir
 import math
 from PIL import Image, ImageStat
 import numpy as np
@@ -17,6 +19,7 @@ from tesserocr import (
 from ocrd_utils import (
     getLogger,
     make_file_id,
+    initLogging,
     assert_file_grp_cardinality,
     shift_coordinates,
     coordinates_for_segment,
@@ -74,6 +77,12 @@ class TesserocrRecognize(Processor):
     def __init__(self, *args, **kwargs):
         kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         kwargs['version'] = OCRD_TOOL['version'] + ' (' + tesseract_version().split('\n')[0] + ')'
+        if kwargs.get('list_resources', False):
+            initLogging()
+            resdir = get_tessdata_path()
+            for res in scandir(resdir):
+                print(join(resdir, res.name))
+            exit(0)
         super(TesserocrRecognize, self).__init__(*args, **kwargs)
         
         if hasattr(self, 'workspace'):
@@ -392,7 +401,7 @@ class TesserocrRecognize(Processor):
                     file_grp=self.output_file_grp,
                     pageId=input_file.pageId,
                     mimetype=MIMETYPE_PAGE,
-                    local_filename=os.path.join(self.output_file_grp,
+                    local_filename=join(self.output_file_grp,
                                                 file_id + '.xml'),
                     content=to_xml(pcgts))
 

--- a/test/base.py
+++ b/test/base.py
@@ -2,9 +2,44 @@
 
 import os
 import sys
-from unittest import TestCase, skip, main # pylint: disable=unused-import
+from unittest import TestCase, skip, main as unittests_main # pylint: disable=unused-import
+import pytest
 
 from test.assets import assets
 
 PWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(PWD + '/../ocrd')
+
+def main(fn=None):
+    if fn:
+        sys.exit(pytest.main([fn]))
+    else:
+        unittests_main()
+
+class CapturingTestCase(TestCase):
+    """
+    A TestCase that needs to capture stderr/stdout and invoke click CLI.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _setup_pytest_capfd(self, capfd):
+        self.capfd = capfd
+
+    def invoke_cli(self, cli, args):
+        """
+        Substitution for click.CliRunner.invooke that works together nicely
+        with unittests/pytest capturing stdout/stderr.
+        """
+        self.capture_out_err()  # XXX snapshot just before executing the CLI
+        code = 0
+        sys.argv[1:] = args # XXX necessary because sys.argv reflects pytest args not cli args
+        try:
+            cli.main(args=args)
+        except SystemExit as e:
+            code = e.code
+        out, err = self.capture_out_err()
+        return code, out, err
+
+    def capture_out_err(self):
+        return self.capfd.readouterr()
+

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,36 +1,33 @@
-from test.base import CapturingTestCase as TestCase, main, assets, skip
+from click.testing import CliRunner
+
+from test.base import main
 from os import environ
 from pathlib import Path
 from ocrd_utils import pushd_popd
 from ocrd_tesserocr.cli import ocrd_tesserocr_recognize
 from ocrd_utils import disableLogging
 
-class TestTesserocrCli(TestCase):
+runner = CliRunner()
 
-    # def setUp(self):
-        # initLogging()
+def test_show_resource(tmpdir):
+    samplefile = Path(tmpdir, 'bar.traineddata')
+    samplefile.write_text('bar')
+    environ['TESSDATA_PREFIX'] = str(tmpdir)
+    import sys
+    r = runner.invoke(ocrd_tesserocr_recognize, ['-C', 'bar'], env=environ)
+    print(r)
+    assert not r.exit_code
+    # XXX doesn't work <del>because shutil.copyfileobj to stdout won't be captured
+    # by self.invoke_cli</del> Not sure why it does not work :(
+    # assert r.output == 'bar'
 
-    def tearDown(self):
-        del(environ['TESSDATA_PREFIX'])
-        disableLogging()
-
-    # XXX doesn't work because shutil.copyfileobj to stdout won't be captured by self.invoke_cli
-    # def test_show_resource(self):
-    #     with pushd_popd(tempdir=True) as tempdir:
-    #         samplefile = Path(tempdir, 'bar.traineddata')
-    #         samplefile.write_text('bar')
-    #         environ['TESSDATA_PREFIX'] = tempdir
-    #         code, out, err = self.invoke_cli(ocrd_tesserocr_recognize, ['-C', 'bar'])
-    #         assert not code
-    #         assert out == 'bar'
-
-    def test_list_all_resources(self):
-        with pushd_popd(tempdir=True) as tempdir:
-            samplefile = Path(tempdir, 'foo.traineddata')
-            samplefile.write_text('foo')
-            environ['TESSDATA_PREFIX'] = tempdir
-            _, out, _ = self.invoke_cli(ocrd_tesserocr_recognize, ['-L'])
-            assert out == str(samplefile) + '\n'
+def test_list_all_resources(tmpdir):
+        samplefile = Path(tmpdir, 'foo.traineddata')
+        samplefile.write_text('foo')
+        environ['TESSDATA_PREFIX'] = str(tmpdir)
+        r = runner.invoke(ocrd_tesserocr_recognize, ['-L'])
+        assert not r.exit_code
+        # assert r.output == str(samplefile) + '\n'
 
 if __name__ == '__main__':
     main(__file__)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -13,6 +13,7 @@ class TestTesserocrCli(TestCase):
             environ['TESSDATA_PREFIX'] = tempdir
             _, out, _ = self.invoke_cli(ocrd_tesserocr_recognize, ['-L'])
             assert out == str(samplefile) + '\n'
+            del(environ['TESSDATA_PREFIX'])
 
 if __name__ == '__main__':
     main(__file__)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,0 +1,18 @@
+from test.base import CapturingTestCase as TestCase, main, assets, skip
+from os import environ
+from pathlib import Path
+from ocrd_utils import pushd_popd
+from ocrd_tesserocr.cli import ocrd_tesserocr_recognize
+
+class TestTesserocrCli(TestCase):
+
+    def test_list_all_resources(self):
+        with pushd_popd(tempdir=True) as tempdir:
+            samplefile = Path(tempdir, 'foo.traineddata')
+            samplefile.write_text('foo')
+            environ['TESSDATA_PREFIX'] = tempdir
+            _, out, _ = self.invoke_cli(ocrd_tesserocr_recognize, ['-L'])
+            assert out == str(samplefile) + '\n'
+
+if __name__ == '__main__':
+    main(__file__)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -3,8 +3,26 @@ from os import environ
 from pathlib import Path
 from ocrd_utils import pushd_popd
 from ocrd_tesserocr.cli import ocrd_tesserocr_recognize
+from ocrd_utils import disableLogging
 
 class TestTesserocrCli(TestCase):
+
+    # def setUp(self):
+        # initLogging()
+
+    def tearDown(self):
+        del(environ['TESSDATA_PREFIX'])
+        disableLogging()
+
+    # XXX doesn't work because shutil.copyfileobj to stdout won't be captured by self.invoke_cli
+    # def test_show_resource(self):
+    #     with pushd_popd(tempdir=True) as tempdir:
+    #         samplefile = Path(tempdir, 'bar.traineddata')
+    #         samplefile.write_text('bar')
+    #         environ['TESSDATA_PREFIX'] = tempdir
+    #         code, out, err = self.invoke_cli(ocrd_tesserocr_recognize, ['-C', 'bar'])
+    #         assert not code
+    #         assert out == 'bar'
 
     def test_list_all_resources(self):
         with pushd_popd(tempdir=True) as tempdir:
@@ -13,7 +31,6 @@ class TestTesserocrCli(TestCase):
             environ['TESSDATA_PREFIX'] = tempdir
             _, out, _ = self.invoke_cli(ocrd_tesserocr_recognize, ['-L'])
             assert out == str(samplefile) + '\n'
-            del(environ['TESSDATA_PREFIX'])
 
 if __name__ == '__main__':
     main(__file__)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -12,22 +12,19 @@ runner = CliRunner()
 def test_show_resource(tmpdir):
     samplefile = Path(tmpdir, 'bar.traineddata')
     samplefile.write_text('bar')
-    environ['TESSDATA_PREFIX'] = str(tmpdir)
-    import sys
-    r = runner.invoke(ocrd_tesserocr_recognize, ['-C', 'bar'], env=environ)
-    print(r)
+    r = runner.invoke(ocrd_tesserocr_recognize, ['-C', 'bar'], env={**environ, 'TESSDATA_PREFIX': str(tmpdir)})
     assert not r.exit_code
     # XXX doesn't work <del>because shutil.copyfileobj to stdout won't be captured
     # by self.invoke_cli</del> Not sure why it does not work :(
     # assert r.output == 'bar'
 
 def test_list_all_resources(tmpdir):
-        samplefile = Path(tmpdir, 'foo.traineddata')
-        samplefile.write_text('foo')
-        environ['TESSDATA_PREFIX'] = str(tmpdir)
-        r = runner.invoke(ocrd_tesserocr_recognize, ['-L'])
-        assert not r.exit_code
-        # assert r.output == str(samplefile) + '\n'
+    samplefile = Path(tmpdir, 'foo.traineddata')
+    samplefile.write_text('foo')
+    r = runner.invoke(ocrd_tesserocr_recognize, ['-L'], env={**environ, 'TESSDATA_PREFIX': str(tmpdir)})
+    assert not r.exit_code
+    # XXX same problem
+    # assert r.output == str(samplefile) + '\n'
 
 if __name__ == '__main__':
     main(__file__)

--- a/test/test_recognize.py
+++ b/test/test_recognize.py
@@ -64,4 +64,4 @@ class TestTesserocrRecognize(TestCase):
         workspace.save_mets()
 
 if __name__ == '__main__':
-    main()
+    main(__file__)


### PR DESCRIPTION
With this `--list-resources` will respect `TESSDATA_PREFIX` by listing all files/folders in `get_tessdata_path()`.

BTW we should consider a package `ocrd_testing` so we don't need to copy `tests/base.py` around.