### PR TITLE
Clipped page image

### DIFF
--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -439,8 +439,8 @@
       "parameters": {
         "operation_level": {
           "type": "string",
-          "enum": ["region", "line"],
-          "default": "region",
+          "enum": ["page", "region", "line"],
+          "default": "page",
           "description": "PAGE XML hierarchy level to operate on"
         }
       }

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -47,6 +47,7 @@ from ocrd_models.ocrd_page import (
     WordType,
     GlyphType,
     TextEquivType,
+    AlternativeImageType,
     to_xml)
 from ocrd_models.ocrd_page_generateds import (
     ReadingDirectionSimpleType,
@@ -278,9 +279,11 @@ class TesserocrRecognize(Processor):
             for variable in tesseract_params:
                 tessapi.SetVariable(variable, tesseract_params[variable])
             for (n, input_file) in enumerate(self.input_files):
+                file_id = make_file_id(input_file, self.output_file_grp)
                 page_id = input_file.pageId or input_file.ID
                 self.logger.info("INPUT FILE %i / %s", n, page_id)
                 pcgts = page_from_file(self.workspace.download_file(input_file))
+                pcgts.set_pcGtsId(file_id)
                 self.add_metadata(pcgts)
                 page = pcgts.get_Page()
                 
@@ -355,6 +358,14 @@ class TesserocrRecognize(Processor):
                     else:
                         self.logger.debug("Recognizing text in page '%s'", page_id)
                         tessapi.Recognize()
+                    page_image_bin = tessapi.GetThresholdedImage()
+                    file_path = self.workspace.save_image_file(
+                        page_image_bin, file_id + '.IMG-BIN',
+                        page_id=page_id,
+                        file_grp=self.output_file_grp)
+                    # update PAGE (reference the image file):
+                    page.add_AlternativeImage(AlternativeImageType(
+                        filename=file_path, comments=page_coords['features'] + ',binarized,clipped'))
                     self._process_regions_in_page(tessapi.GetIterator(), page, page_coords, dpi)
                 elif inlevel == 'cell':
                     # Tables are obligatorily recursive regions;
@@ -385,8 +396,6 @@ class TesserocrRecognize(Processor):
                 # if inlevel != 'none' and self.parameter['shrink_polygons']:
                 #     page_shrink_higher_coordinate_levels(inlevel, outlevel, pcgts)
                 
-                file_id = make_file_id(input_file, self.output_file_grp)
-                pcgts.set_pcGtsId(file_id)
                 self.workspace.add_file(
                     ID=file_id,
                     file_grp=self.output_file_grp,


### PR DESCRIPTION
During layout analysis on the page level, Tesseract internally detects images and separators. Their bounding boxes can be queried via iterators, but the precise polygons are not available, and for sparse mode, only text blocks are returned. Moreover, we usually do not suppress separators and images in the foreground of consumers, even if we do annotate them in PAGE. This often yields suboptimal results, especially for OCRs like Ocropy or Calamari.

This PR therefore queries the internal binarized and nontext-suppressed (i.e. clipped) page-level image and annotates it as page-level derived image (with additional features `binarized,clipped`). As long as consumers do not opt out of the usual AlternativeImage retrieval priority, they will therefore get images without nontextual foreground.
