### PR TITLE
Drop custom tessdata location, properly support moduledir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,6 @@ deps:
 
 # Install Python deps for test via pip
 deps-test:
-	$(PIP) install -U pip
 	$(PIP) install -r requirements_test.txt
 
 # Build docker image
@@ -93,13 +92,15 @@ docker:
 
 # Install this package
 install: deps
-	$(PIP) install -U pip
 	$(PIP) install .
 
 # Run unit tests
 test: test/assets deps-test
 	# declare -p HTTP_PROXY
-	$(PYTHON) -m pytest --continue-on-collection-errors test $(PYTEST_ARGS)
+	#$(PYTHON) -m pytest --continue-on-collection-errors test $(PYTEST_ARGS)
+	# workaround for missing module-init separation: run separately
+	$(PYTHON) -m pytest --continue-on-collection-errors test/test_cli.py $(PYTEST_ARGS)
+	$(PYTHON) -m pytest --continue-on-collection-errors test/test_{recognize,segment_{region,line,word}}.py $(PYTEST_ARGS)
 
 # Run unit tests and determine test coverage
 coverage: deps-test

--- a/ocrd_tesserocr/binarize.py
+++ b/ocrd_tesserocr/binarize.py
@@ -20,7 +20,7 @@ from ocrd_models.ocrd_page import (
 )
 from ocrd import Processor
 
-from .config import get_tessdata_path, OCRD_TOOL
+from .config import OCRD_TOOL
 
 TOOL = 'ocrd-tesserocr-binarize'
 
@@ -52,8 +52,8 @@ class TesserocrBinarize(Processor):
         assert_file_grp_cardinality(self.output_file_grp, 1)
 
         oplevel = self.parameter['operation_level']
-        
-        with PyTessBaseAPI(path=get_tessdata_path()) as tessapi:
+
+        with PyTessBaseAPI() as tessapi:
             for n, input_file in enumerate(self.input_files):
                 file_id = make_file_id(input_file, self.output_file_grp)
                 page_id = input_file.pageId or input_file.ID
@@ -61,7 +61,7 @@ class TesserocrBinarize(Processor):
                 pcgts = page_from_file(self.workspace.download_file(input_file))
                 self.add_metadata(pcgts)
                 page = pcgts.get_Page()
-                
+
                 page_image, page_xywh, _ = self.workspace.image_from_page(
                     page, page_id)
                 LOG.info("Binarizing on '%s' level in page '%s'", oplevel, page_id)

--- a/ocrd_tesserocr/config.py
+++ b/ocrd_tesserocr/config.py
@@ -3,13 +3,4 @@ import json
 from os.path import join
 from pkg_resources import resource_string
 
-import tesserocr
-
-from ocrd.resource_manager import OcrdResourceManager
-
-def get_tessdata_path():
-    if 'TESSDATA_PREFIX' in os.environ:
-        return os.environ['TESSDATA_PREFIX']
-    return join(OcrdResourceManager().default_resource_dir, 'ocrd-tesserocr-recognize')
-
 OCRD_TOOL = json.loads(resource_string(__name__, 'ocrd-tool.json').decode('utf8'))

--- a/ocrd_tesserocr/crop.py
+++ b/ocrd_tesserocr/crop.py
@@ -24,7 +24,7 @@ from ocrd_models.ocrd_page import (
 from ocrd_models.ocrd_page_generateds import BorderType
 from ocrd import Processor
 
-from .config import get_tessdata_path, OCRD_TOOL
+from .config import OCRD_TOOL
 from .recognize import polygon_for_parent
 
 TOOL = 'ocrd-tesserocr-crop'
@@ -36,9 +36,13 @@ class TesserocrCrop(Processor):
         kwargs['version'] = OCRD_TOOL['version']
         super(TesserocrCrop, self).__init__(*args, **kwargs)
 
+    @property
+    def moduledir(self):
+        return tesserocr.get_languages()[0]
+
     def process(self):
         """Performs page cropping with Tesseract on the workspace.
-        
+
         Open and deserialize PAGE input files and their respective images.
         Set up Tesseract to detect text blocks on each page, and find
         the largest coordinate extent spanning all of them. Use this
@@ -57,7 +61,7 @@ class TesserocrCrop(Processor):
         assert_file_grp_cardinality(self.input_file_grp, 1)
         assert_file_grp_cardinality(self.output_file_grp, 1)
 
-        with tesserocr.PyTessBaseAPI(path=get_tessdata_path()) as tessapi:
+        with tesserocr.PyTessBaseAPI() as tessapi:
             # disable table detection here (tables count as text blocks),
             # because we do not want to risk confusing the spine with
             # a column separator and thus creeping into a neighbouring

--- a/ocrd_tesserocr/deskew.py
+++ b/ocrd_tesserocr/deskew.py
@@ -27,7 +27,7 @@ from ocrd_models.ocrd_page import (
 )
 from ocrd import Processor
 
-from .config import get_tessdata_path, OCRD_TOOL
+from .config import OCRD_TOOL
 
 TOOL = 'ocrd-tesserocr-deskew'
 
@@ -62,7 +62,6 @@ class TesserocrDeskew(Processor):
         oplevel = self.parameter['operation_level']
         
         with PyTessBaseAPI(
-                path=get_tessdata_path(),
                 lang="osd", # osd required for legacy init!
                 oem=OEM.TESSERACT_LSTM_COMBINED, # legacy required for OSD!
                 psm=PSM.AUTO_OSD

--- a/ocrd_tesserocr/fontshape.py
+++ b/ocrd_tesserocr/fontshape.py
@@ -18,7 +18,7 @@ from ocrd_models.ocrd_page import (
 from ocrd_modelfactory import page_from_file
 from ocrd import Processor
 
-from .config import get_tessdata_path, OCRD_TOOL
+from .config import OCRD_TOOL
 
 TOOL = 'ocrd-tesserocr-fontshape'
 

--- a/ocrd_tesserocr/fontshape.py
+++ b/ocrd_tesserocr/fontshape.py
@@ -4,7 +4,9 @@ from PIL import Image, ImageStat
 
 from tesserocr import (
     RIL, PSM, OEM,
-    PyTessBaseAPI, get_languages as get_languages_)
+    PyTessBaseAPI, 
+    get_languages
+)
 
 from ocrd_utils import (
     getLogger,
@@ -22,18 +24,16 @@ from .config import OCRD_TOOL
 
 TOOL = 'ocrd-tesserocr-fontshape'
 
-def get_languages(*args, **kwargs):
-    """
-    Wraps tesserocr.get_languages() with a fixed path parameter.
-    """
-    return get_languages_(*args, path=get_tessdata_path(), **kwargs)
-
 class TesserocrFontShape(Processor):
 
     def __init__(self, *args, **kwargs):
         kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         kwargs['version'] = OCRD_TOOL['version']
         super(TesserocrFontShape, self).__init__(*args, **kwargs)
+
+    @property
+    def moduledir(self):
+        return get_languages()[0]
 
     def process(self):
         """Detect font shapes via rule-based OCR with Tesseract on the workspace.
@@ -60,8 +60,7 @@ class TesserocrFontShape(Processor):
         if model not in get_languages()[1]:
             raise Exception("model " + model + " (needed for font style detection) is not installed")
         
-        with PyTessBaseAPI(path=get_tessdata_path(),
-                           #oem=OEM.TESSERACT_LSTM_COMBINED, # legacy required for OSD or WordFontAttributes!
+        with PyTessBaseAPI(#oem=OEM.TESSERACT_LSTM_COMBINED, # legacy required for OSD or WordFontAttributes!
                            oem=OEM.TESSERACT_ONLY, # legacy required for OSD or WordFontAttributes!
                            lang=model) as tessapi:
             LOG.info("Using model '%s' in %s for recognition at the word level",

--- a/ocrd_tesserocr/ocrd-tool.json
+++ b/ocrd_tesserocr/ocrd-tool.json
@@ -207,7 +207,7 @@
           "description": "Tesseract OCR engine mode to use:\n* Run Tesseract only - fastest,\n* Run just the LSTM line recognizer. (>=v4.00),\n*Run the LSTM recognizer, but allow fallback to Tesseract when things get difficult. (>=v4.00),\n*Run both and combine results - best accuracy."
         }
       },
-      "resource_locations": ["data"],
+      "resource_locations": ["module"],
       "resources": [
         {
           "url": "https://ub-backup.bib.uni-mannheim.de/~stweil/ocrd-train/data/Fraktur_5000000/tessdata_fast/Fraktur_50000000.334_450937.traineddata",

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -265,7 +265,7 @@ class TesserocrRecognize(Processor):
         model (among the models given in ``model``), enable ``auto_model``. To constrain
         models by type (called OCR engine mode), use ``oem``.
         """
-        self.logger.debug("TESSDATA: %s, installed Tesseract models: %s", *get_languages()[1])
+        self.logger.debug("TESSDATA: %s, installed Tesseract models: %s", *get_languages())
 
         assert_file_grp_cardinality(self.input_file_grp, 1)
         assert_file_grp_cardinality(self.output_file_grp, 1)

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -348,8 +348,7 @@ class TesserocrRecognize(Processor):
             for variable in tesseract_params:
                 tessapi.SetVariable(variable, tesseract_params[variable])
             # Initialize Tesseract (loading model)
-            tessapi.InitFull(path=get_tessdata_path(),
-                             lang=model,
+            tessapi.InitFull(lang=model,
                              oem=getattr(OEM, self.parameter['oem']))
             # Iterate input files
             for (n, input_file) in enumerate(self.input_files):

--- a/ocrd_tesserocr/segment.py
+++ b/ocrd_tesserocr/segment.py
@@ -18,6 +18,7 @@ class TesserocrSegment(Processor):
         if hasattr(self, 'workspace'):
             recognize_kwargs = {**kwargs}
             recognize_kwargs.pop('dump_json', None)
+            recognize_kwargs.pop('dump_module_dir', None)
             recognize_kwargs.pop('show_help', None)
             recognize_kwargs.pop('show_version', None)
             recognize_kwargs['parameter'] = self.parameter

--- a/ocrd_tesserocr/segment_line.py
+++ b/ocrd_tesserocr/segment_line.py
@@ -18,6 +18,7 @@ class TesserocrSegmentLine(Processor):
         if hasattr(self, 'workspace'):
             recognize_kwargs = {**kwargs}
             recognize_kwargs.pop('dump_json', None)
+            recognize_kwargs.pop('dump_module_dir', None)
             recognize_kwargs.pop('show_help', None)
             recognize_kwargs.pop('show_version', None)
             recognize_kwargs['parameter'] = self.parameter

--- a/ocrd_tesserocr/segment_region.py
+++ b/ocrd_tesserocr/segment_region.py
@@ -18,6 +18,7 @@ class TesserocrSegmentRegion(Processor):
         if hasattr(self, 'workspace'):
             recognize_kwargs = {**kwargs}
             recognize_kwargs.pop('dump_json', None)
+            recognize_kwargs.pop('dump_module_dir', None)
             recognize_kwargs.pop('show_help', None)
             recognize_kwargs.pop('show_version', None)
             recognize_kwargs['parameter'] = self.parameter

--- a/ocrd_tesserocr/segment_table.py
+++ b/ocrd_tesserocr/segment_table.py
@@ -18,6 +18,7 @@ class TesserocrSegmentTable(Processor):
         if hasattr(self, 'workspace'):
             recognize_kwargs = {**kwargs}
             recognize_kwargs.pop('dump_json', None)
+            recognize_kwargs.pop('dump_module_dir', None)
             recognize_kwargs.pop('show_help', None)
             recognize_kwargs.pop('show_version', None)
             recognize_kwargs['parameter'] = self.parameter

--- a/ocrd_tesserocr/segment_word.py
+++ b/ocrd_tesserocr/segment_word.py
@@ -18,6 +18,7 @@ class TesserocrSegmentWord(Processor):
         if hasattr(self, 'workspace'):
             recognize_kwargs = {**kwargs}
             recognize_kwargs.pop('dump_json', None)
+            recognize_kwargs.pop('dump_module_dir', None)
             recognize_kwargs.pop('show_help', None)
             recognize_kwargs.pop('show_version', None)
             recognize_kwargs['parameter'] = self.parameter

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -12,10 +12,12 @@ def test_show_resource(tmpdir, monkeypatch):
     samplefile.write_text('bar')
     # simulate a Tesseract compiled with custom tessdata dir
     monkeypatch.setenv('TESSDATA_PREFIX', str(tmpdir))
+    # does not work (thus, tesserocr must not have been loaded already):
+    #monkeypatch.delitem(sys.modules, 'tesserocr')
     # envvars influence tesserocr's module initialization
     from ocrd_tesserocr.cli import ocrd_tesserocr_recognize
-    r = runner.invoke(ocrd_tesserocr_recognize, ['-C', 'bar'])
-    assert not r.exit_code
+    r = runner.invoke(ocrd_tesserocr_recognize, ['-C', 'bar.traineddata'])
+    assert not r.exit_code, r.output
     # XXX doesn't work <del>because shutil.copyfileobj to stdout won't be captured
     # by self.invoke_cli</del> Not sure why it does not work :(
     # assert r.output == 'bar'

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -11,7 +11,7 @@ runner = CliRunner()
 def test_show_resource(tmpdir, monkeypatch):
     samplefile = Path(tmpdir, 'bar.traineddata')
     samplefile.write_text('bar')
-    monkeypatch.setenv('TESSDATA_PREFIX': str(tmpdir))
+    monkeypatch.setenv('TESSDATA_PREFIX', str(tmpdir))
     r = runner.invoke(ocrd_tesserocr_recognize, ['-C', 'bar'])
     assert not r.exit_code
     # XXX doesn't work <del>because shutil.copyfileobj to stdout won't be captured
@@ -21,7 +21,7 @@ def test_show_resource(tmpdir, monkeypatch):
 def test_list_all_resources(tmpdir, monkeypatch):
     samplefile = Path(tmpdir, 'foo.traineddata')
     samplefile.write_text('foo')
-    monkeypatch.setenv('TESSDATA_PREFIX': str(tmpdir))
+    monkeypatch.setenv('TESSDATA_PREFIX', str(tmpdir))
     r = runner.invoke(ocrd_tesserocr_recognize, ['-L'])
     assert not r.exit_code
     # XXX same problem

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -3,7 +3,6 @@ from click.testing import CliRunner
 from test.base import main
 from pathlib import Path
 from ocrd_utils import pushd_popd
-from ocrd_tesserocr.cli import ocrd_tesserocr_recognize
 from ocrd_utils import disableLogging
 
 runner = CliRunner()
@@ -11,7 +10,10 @@ runner = CliRunner()
 def test_show_resource(tmpdir, monkeypatch):
     samplefile = Path(tmpdir, 'bar.traineddata')
     samplefile.write_text('bar')
+    # simulate a Tesseract compiled with custom tessdata dir
     monkeypatch.setenv('TESSDATA_PREFIX', str(tmpdir))
+    # envvars influence tesserocr's module initialization
+    from ocrd_tesserocr.cli import ocrd_tesserocr_recognize
     r = runner.invoke(ocrd_tesserocr_recognize, ['-C', 'bar'])
     assert not r.exit_code
     # XXX doesn't work <del>because shutil.copyfileobj to stdout won't be captured
@@ -21,7 +23,10 @@ def test_show_resource(tmpdir, monkeypatch):
 def test_list_all_resources(tmpdir, monkeypatch):
     samplefile = Path(tmpdir, 'foo.traineddata')
     samplefile.write_text('foo')
+    # simulate a Tesseract compiled with custom tessdata dir
     monkeypatch.setenv('TESSDATA_PREFIX', str(tmpdir))
+    # envvars influence tesserocr's module initialization
+    from ocrd_tesserocr.cli import ocrd_tesserocr_recognize
     r = runner.invoke(ocrd_tesserocr_recognize, ['-L'])
     assert not r.exit_code
     # XXX same problem

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,7 +1,6 @@
 from click.testing import CliRunner
 
 from test.base import main
-from os import environ
 from pathlib import Path
 from ocrd_utils import pushd_popd
 from ocrd_tesserocr.cli import ocrd_tesserocr_recognize
@@ -9,19 +8,21 @@ from ocrd_utils import disableLogging
 
 runner = CliRunner()
 
-def test_show_resource(tmpdir):
+def test_show_resource(tmpdir, monkeypatch):
     samplefile = Path(tmpdir, 'bar.traineddata')
     samplefile.write_text('bar')
-    r = runner.invoke(ocrd_tesserocr_recognize, ['-C', 'bar'], env={**environ, 'TESSDATA_PREFIX': str(tmpdir)})
+    monkeypatch.setenv('TESSDATA_PREFIX': str(tmpdir))
+    r = runner.invoke(ocrd_tesserocr_recognize, ['-C', 'bar'])
     assert not r.exit_code
     # XXX doesn't work <del>because shutil.copyfileobj to stdout won't be captured
     # by self.invoke_cli</del> Not sure why it does not work :(
     # assert r.output == 'bar'
 
-def test_list_all_resources(tmpdir):
+def test_list_all_resources(tmpdir, monkeypatch):
     samplefile = Path(tmpdir, 'foo.traineddata')
     samplefile.write_text('foo')
-    r = runner.invoke(ocrd_tesserocr_recognize, ['-L'], env={**environ, 'TESSDATA_PREFIX': str(tmpdir)})
+    monkeypatch.setenv('TESSDATA_PREFIX': str(tmpdir))
+    r = runner.invoke(ocrd_tesserocr_recognize, ['-L'])
     assert not r.exit_code
     # XXX same problem
     # assert r.output == str(samplefile) + '\n'


### PR DESCRIPTION
This is the companion to OCR-D/core#904, doing away with overriding the path to `tessdata` and instead using the `self.moduledir` mechanism to tell core where it expects models to be stored.

~~Draft because OCR-D/core#904 needs to be finished before properly testing this.~~