### PR TITLE
override instead of wrap TesserocrRecognize in other processors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,9 @@ orbs:
 
 commands:
   install-test-coverage:
+    parameters:
+      python-image:
+        type: string
     steps:
       - checkout
       - run: sudo make deps-ubuntu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,17 +3,21 @@ version: 2.1
 orbs:
   codecov: codecov/codecov@1.0.5
 
-commands:
-  install-test-coverage:
+
+jobs:
+
+  build-python:
     parameters:
-      python-image:
+      python-version:
         type: string
+    docker:
+      - image: cimg/python:<< parameters.python-version >>
     steps:
       - checkout
       - run: sudo make deps-ubuntu
       - when:
           condition:
-            equal: [ 'cimg/python:3.6', << parameters.python-image >> ]
+            equal: [ '3.6', << parameters.python-version >> ]
           steps:
             # speed-up build time for end-of-life Python by holding at latest binary:
             - run: pip install --prefer-binary -U opencv-python-headless numpy
@@ -23,26 +27,10 @@ commands:
       - run: make coverage
       - codecov/upload
 
-jobs:
-
-  build-python:
-    parameters:
-      python-image:
-        type: string
-    docker:
-      - image: << parameters.python-image >>
-    steps:
-      - install-test-coverage
-
 workflows:
   build:
     jobs:
       - build-python:
           matrix:
             parameters:
-              python-image:
-                - 'cimg/python:3.6'
-                - 'cimg/python:3.7'
-                - 'cimg/python:3.8'
-                - 'cimg/python:3.9'
-                - 'cimg/python:3.10'
+              python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,39 +3,27 @@ version: 2.1
 orbs:
   codecov: codecov/codecov@1.0.5
 
-executors:
-  ubuntu1804:
-    docker:
-      - image: ocrd/core
-
 commands:
   install-test-coverage:
-    parameters:
-      python-version:
-        type: string
     steps:
-      - run: apt-get update
-      - run: apt-get install -y software-properties-common imagemagick
-      - run: add-apt-repository -y ppa:deadsnakes/ppa
-      - run: apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Europe/Berlin apt-get install -y --no-install-recommends make git curl python<<parameters.python-version>>
       - checkout
       - run: make deps-ubuntu
-      - run: make install PYTHON=python<<parameters.python-version>>
+      - run: make install
       - run: ocrd resmgr download ocrd-tesserocr-recognize deu.traineddata
-      - run: make test-cli PYTHON=python<<parameters.python-version>>
-      - run: make coverage PYTHON=python<<parameters.python-version>>
+      - run: make test-cli
+      - run: make coverage
       - codecov/upload
 
 jobs:
 
   build-python:
-    executor: ubuntu1804
     parameters:
-      python-version:
+      python-image:
         type: string
+    docker:
+      - image: << parameters.python-image >>
     steps:
-      - install-test-coverage:
-          python-version: <<parameters.python-version>>
+      - install-test-coverage
 
 workflows:
   build:
@@ -43,8 +31,9 @@ workflows:
       - build-python:
           matrix:
             parameters:
-              python-version:
-                - '3.6'
-                - '3.7'
-                - '3.8'
-                - '3.9'
+              python-image:
+                - 'cimg/python:3.6'
+                - 'cimg/python:3.7'
+                - 'cimg/python:3.8'
+                - 'cimg/python:3.9'
+                - 'cimg/python:3.10'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,8 @@ commands:
       - checkout
       - run: sudo make deps-ubuntu
       - when:
-          equal: [ 'cimg/python:3.6', << parameters.python-image >> ]
+          condition:
+            equal: [ 'cimg/python:3.6', << parameters.python-image >> ]
           steps:
             # speed-up build time for end-of-life Python by holding at latest binary:
             - run: pip install --prefer-binary -U opencv-python-headless numpy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ commands:
   install-test-coverage:
     steps:
       - checkout
-      - run: make deps-ubuntu
+      - run: sudo make deps-ubuntu
       - when:
           equal: [ 'cimg/python:3.6', << parameters.python-image >> ]
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,8 @@ jobs:
             # speed-up build time for end-of-life Python by holding at latest binary:
             - run: pip install --prefer-binary -U opencv-python-headless numpy
       - run: make install
+      # PPA tessdata prefix (= ocrd_tesserocr moduledir) is owned by root
+      - run: sudo chmod go+w `dpkg-query -L tesseract-ocr-eng | sed -n s,/eng.traineddata,,p`
       - run: ocrd resmgr download ocrd-tesserocr-recognize deu.traineddata
       - run: make test-cli
       - run: make coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,11 @@ commands:
     steps:
       - checkout
       - run: make deps-ubuntu
+      - when:
+          equal: [ 'cimg/python:3.6', << parameters.python-image >> ]
+          steps:
+            # speed-up build time for end-of-life Python by holding at latest binary:
+            - run: pip install --prefer-binary -U opencv-python-headless numpy
       - run: make install
       - run: ocrd resmgr download ocrd-tesserocr-recognize deu.traineddata
       - run: make test-cli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
       # PPA tessdata prefix (= ocrd_tesserocr moduledir) is owned by root
       - run: sudo chmod go+w `dpkg-query -L tesseract-ocr-eng | sed -n s,/eng.traineddata,,p`
       - run: ocrd resmgr download ocrd-tesserocr-recognize deu.traineddata
+      - run: ocrd resmgr download ocrd-tesserocr-recognize Fraktur.traineddata
       - run: make test-cli
       - run: make coverage
       - codecov/upload

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 Fixed:
 
+ * segment/recognize: fix `shrink_polygons`
+ * segment/recognize: fix reinit scope (for `xpath_model` and `auto_model`)
  * CI: test multiple Python versions independent of ocrd/core image
  * CI: speed up build for EOL Python 3.6
  * CI: chmod o+w tessdata directory of PPA/OS Tesseract
@@ -17,6 +19,7 @@ Changed:
  * adapted to Shapely v2
  * *: inherit from recognize (but override logger)
  * segment*: delegate constructor instead of wrapping instance
+ * requires ocrd==2.48
 
 ## [0.16.0] - 2022-10-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+Fixed:
+
+ * CI: test multiple Python versions independent of ocrd/core image
+ * CI: speed up build for EOL Python 3.6
+ * CI: chmod o+w tessdata directory of PPA/OS Tesseract
+ * deps-ubuntu: allow installation of PPA Tesseract to fail (for newer OS)
+
+Changed:
+
+ * adapted to Shapely v2
+ * *: inherit from recognize (but override logger)
+ * segment*: delegate constructor instead of wrapping instance
+
 ## [0.16.0] - 2022-10-25
 
 Changed:

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,7 @@ help:
 #  for details.)
 deps-ubuntu:
 	apt-get install -y --no-install-recommends software-properties-common
-	-add-apt-repository -y ppa:alex-p/tesseract-ocr
-	apt-get update
+	-add-apt-repository -u -y ppa:alex-p/tesseract-ocr
 	apt-get install -y \
 		g++ \
 		git \

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ help:
 #  for details.)
 deps-ubuntu:
 	apt-get install -y --no-install-recommends software-properties-common
-	add-apt-repository -y ppa:alex-p/tesseract-ocr
+	-add-apt-repository -y ppa:alex-p/tesseract-ocr
 	apt-get update
 	apt-get install -y \
 		g++ \

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ deps-ubuntu:
 		libtesseract-dev \
 		libleptonica-dev \
 		tesseract-ocr-eng \
+		tesseract-ocr-script-frak \
 		tesseract-ocr
 
 # Install Python deps for install via pip
@@ -90,11 +91,11 @@ install: deps
 
 # Run unit tests
 test: test/assets deps-test
-	# declare -p HTTP_PROXY
-	#$(PYTHON) -m pytest --continue-on-collection-errors test $(PYTEST_ARGS)
-	# workaround for missing module-init separation: run separately
+	@# declare -p HTTP_PROXY
+	#$(PYTHON) -m pytest -n auto --continue-on-collection-errors test $(PYTEST_ARGS)
+	# workaround for pytest-xdist not isolating setenv calls in click.CliRunner from each other:
 	$(PYTHON) -m pytest --continue-on-collection-errors test/test_cli.py $(PYTEST_ARGS)
-	$(PYTHON) -m pytest --continue-on-collection-errors test/test_{recognize,segment_{region,line,word}}.py $(PYTEST_ARGS)
+	$(PYTHON) -m pytest -n auto --continue-on-collection-errors test/test_{segment_{region,line,word},recognize}.py $(PYTEST_ARGS)
 
 # Run unit tests and determine test coverage
 coverage: deps-test

--- a/ocrd_tesserocr/binarize.py
+++ b/ocrd_tesserocr/binarize.py
@@ -21,15 +21,16 @@ from ocrd_models.ocrd_page import (
 from ocrd import Processor
 
 from .config import OCRD_TOOL
+from .recognize import TesserocrRecognize
 
 TOOL = 'ocrd-tesserocr-binarize'
 
-class TesserocrBinarize(Processor):
-
+class TesserocrBinarize(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
-        kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
-        kwargs['version'] = OCRD_TOOL['version']
-        super(TesserocrBinarize, self).__init__(*args, **kwargs)
+        kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
+        super().__init__(*args, **kwargs)
+        if hasattr(self, 'parameter'):
+            self.logger = getLogger('processor.TesserocrBinarize')
 
     def process(self):
         """Performs binarization of the region / line with Tesseract on the workspace.
@@ -47,7 +48,6 @@ class TesserocrBinarize(Processor):
         
         Produce a new output file by serialising the resulting hierarchy.
         """
-        LOG = getLogger('processor.TesserocrBinarize')
         assert_file_grp_cardinality(self.input_file_grp, 1)
         assert_file_grp_cardinality(self.output_file_grp, 1)
 
@@ -58,7 +58,7 @@ class TesserocrBinarize(Processor):
             for n, input_file in enumerate(self.input_files):
                 file_id = make_file_id(input_file, self.output_file_grp)
                 page_id = input_file.pageId or input_file.ID
-                LOG.info("INPUT FILE %i / %s", n, page_id)
+                self.logger.info("INPUT FILE %i / %s", n, page_id)
                 pcgts = page_from_file(self.workspace.download_file(input_file))
                 self.add_metadata(pcgts)
                 page = pcgts.get_Page()
@@ -66,17 +66,17 @@ class TesserocrBinarize(Processor):
                     page, page_id)
                 if self.parameter['dpi'] > 0:
                     dpi = self.parameter['dpi']
-                    LOG.info("Page '%s' images will use %d DPI from parameter override", page_id, dpi)
+                    self.logger.info("Page '%s' images will use %d DPI from parameter override", page_id, dpi)
                 elif page_image_info.resolution != 1:
                     dpi = page_image_info.resolution
                     if page_image_info.resolutionUnit == 'cm':
                         dpi = round(dpi * 2.54)
-                    LOG.info("Page '%s' images will use %d DPI from image meta-data", page_id, dpi)
+                    self.logger.info("Page '%s' images will use %d DPI from image meta-data", page_id, dpi)
                 else:
                     dpi = 0
-                    LOG.info("Page '%s' images will use DPI estimated from segmentation", page_id)
+                    self.logger.info("Page '%s' images will use DPI estimated from segmentation", page_id)
                 tessapi.SetVariable('user_defined_dpi', str(dpi))
-                LOG.info("Binarizing on '%s' level in page '%s'", oplevel, page_id)
+                self.logger.info("Binarizing on '%s' level in page '%s'", oplevel, page_id)
 
                 if oplevel == 'page':
                     tessapi.SetPageSegMode(PSM.AUTO_ONLY)
@@ -99,11 +99,11 @@ class TesserocrBinarize(Processor):
                         page.add_AlternativeImage(AlternativeImageType(
                             filename=file_path, comments=features))
                     else:
-                        LOG.error('Cannot binarize %s', "page '%s'" % page_id)
+                        self.logger.error('Cannot binarize %s', "page '%s'" % page_id)
                 else:
                     regions = page.get_TextRegion() + page.get_TableRegion()
                     if not regions:
-                        LOG.warning("Page '%s' contains no text regions", page_id)
+                        self.logger.warning("Page '%s' contains no text regions", page_id)
                     for region in regions:
                         region_image, region_xywh = self.workspace.image_from_segment(
                             region, page_image, page_xywh)
@@ -115,8 +115,8 @@ class TesserocrBinarize(Processor):
                         elif isinstance(region, TextRegionType):
                             lines = region.get_TextLine()
                             if not lines:
-                                LOG.warning("Page '%s' region '%s' contains no text lines",
-                                            page_id, region.id)
+                                self.logger.warning("Page '%s' region '%s' contains no text lines",
+                                                    page_id, region.id)
                             for line in lines:
                                 line_image, line_xywh = self.workspace.image_from_segment(
                                     line, region_image, region_xywh)
@@ -137,14 +137,13 @@ class TesserocrBinarize(Processor):
                     content=to_xml(pcgts))
 
     def _process_segment(self, tessapi, ril, segment, image, xywh, where, page_id, file_id):
-        LOG = getLogger('processor.TesserocrBinarize')
         tessapi.SetImage(image)
         image_bin = None
         layout = tessapi.AnalyseLayout()
         if layout:
             image_bin = layout.GetBinaryImage(ril)
         if not image_bin:
-            LOG.error('Cannot binarize %s', where)
+            self.logger.error('Cannot binarize %s', where)
             return
         # update METS (add the image file):
         file_path = self.workspace.save_image_file(image_bin,

--- a/ocrd_tesserocr/binarize.py
+++ b/ocrd_tesserocr/binarize.py
@@ -127,9 +127,9 @@ class TesserocrBinarize(TesserocrRecognize):
                 file_id = make_file_id(input_file, self.output_file_grp)
                 pcgts.set_pcGtsId(file_id)
                 self.workspace.add_file(
-                    ID=file_id,
+                    file_id=file_id,
                     file_grp=self.output_file_grp,
-                    pageId=input_file.pageId,
+                    page_id=input_file.pageId,
                     mimetype=MIMETYPE_PAGE,
                     local_filename=os.path.join(self.output_file_grp,
                                                 file_id + '.xml'),

--- a/ocrd_tesserocr/binarize.py
+++ b/ocrd_tesserocr/binarize.py
@@ -27,9 +27,6 @@ TOOL = 'ocrd-tesserocr-binarize'
 class TesserocrBinarize(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
-        # workaround for core#998
-        if kwargs['ocrd_tool'] is None:
-            kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         super().__init__(*args, **kwargs)
         if hasattr(self, 'parameter'):
             self.logger = getLogger('processor.TesserocrBinarize')

--- a/ocrd_tesserocr/binarize.py
+++ b/ocrd_tesserocr/binarize.py
@@ -18,7 +18,6 @@ from ocrd_models.ocrd_page import (
     TextRegionType,
     to_xml
 )
-from ocrd import Processor
 
 from .config import OCRD_TOOL
 from .recognize import TesserocrRecognize

--- a/ocrd_tesserocr/binarize.py
+++ b/ocrd_tesserocr/binarize.py
@@ -27,6 +27,9 @@ TOOL = 'ocrd-tesserocr-binarize'
 class TesserocrBinarize(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
+        # workaround for core#998
+        if kwargs['ocrd_tool'] is None:
+            kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         super().__init__(*args, **kwargs)
         if hasattr(self, 'parameter'):
             self.logger = getLogger('processor.TesserocrBinarize')

--- a/ocrd_tesserocr/config.py
+++ b/ocrd_tesserocr/config.py
@@ -1,6 +1,4 @@
-import os
 import json
-from os.path import join
 from pkg_resources import resource_string
 
 OCRD_TOOL = json.loads(resource_string(__name__, 'ocrd-tool.json').decode('utf8'))

--- a/ocrd_tesserocr/crop.py
+++ b/ocrd_tesserocr/crop.py
@@ -23,7 +23,6 @@ from ocrd_models.ocrd_page import (
     BorderType,
     to_xml
 )
-from ocrd import Processor
 
 from .config import OCRD_TOOL
 from .recognize import TesserocrRecognize, polygon_for_parent

--- a/ocrd_tesserocr/crop.py
+++ b/ocrd_tesserocr/crop.py
@@ -104,9 +104,9 @@ class TesserocrCrop(TesserocrRecognize):
 
                 pcgts.set_pcGtsId(file_id)
                 self.workspace.add_file(
-                    ID=file_id,
+                    file_id=file_id,
                     file_grp=self.output_file_grp,
-                    pageId=input_file.pageId,
+                    page_id=input_file.pageId,
                     mimetype=MIMETYPE_PAGE,
                     local_filename=os.path.join(self.output_file_grp,
                                                 file_id + '.xml'),

--- a/ocrd_tesserocr/crop.py
+++ b/ocrd_tesserocr/crop.py
@@ -32,9 +32,6 @@ TOOL = 'ocrd-tesserocr-crop'
 class TesserocrCrop(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
-        # workaround for core#998
-        if kwargs['ocrd_tool'] is None:
-            kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         super().__init__(*args, **kwargs)
         if hasattr(self, 'parameter'):
             self.logger = getLogger('processor.TesserocrCrop')

--- a/ocrd_tesserocr/crop.py
+++ b/ocrd_tesserocr/crop.py
@@ -32,6 +32,9 @@ TOOL = 'ocrd-tesserocr-crop'
 class TesserocrCrop(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
+        # workaround for core#998
+        if kwargs['ocrd_tool'] is None:
+            kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         super().__init__(*args, **kwargs)
         if hasattr(self, 'parameter'):
             self.logger = getLogger('processor.TesserocrCrop')

--- a/ocrd_tesserocr/crop.py
+++ b/ocrd_tesserocr/crop.py
@@ -18,27 +18,24 @@ from ocrd_utils import (
 )
 from ocrd_modelfactory import page_from_file
 from ocrd_models.ocrd_page import (
-    CoordsType, AlternativeImageType,
+    CoordsType,
+    AlternativeImageType,
+    BorderType,
     to_xml
 )
-from ocrd_models.ocrd_page_generateds import BorderType
 from ocrd import Processor
 
 from .config import OCRD_TOOL
-from .recognize import polygon_for_parent
+from .recognize import TesserocrRecognize, polygon_for_parent
 
 TOOL = 'ocrd-tesserocr-crop'
 
-class TesserocrCrop(Processor):
-
+class TesserocrCrop(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
-        kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
-        kwargs['version'] = OCRD_TOOL['version']
-        super(TesserocrCrop, self).__init__(*args, **kwargs)
-
-    @property
-    def moduledir(self):
-        return tesserocr.get_languages()[0]
+        kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
+        super().__init__(*args, **kwargs)
+        if hasattr(self, 'parameter'):
+            self.logger = getLogger('processor.TesserocrCrop')
 
     def process(self):
         """Performs page cropping with Tesseract on the workspace.
@@ -57,7 +54,6 @@ class TesserocrCrop(Processor):
         
         Produce new output files by serialising the resulting hierarchy.
         """
-        LOG = getLogger('processor.TesserocrCrop')
         assert_file_grp_cardinality(self.input_file_grp, 1)
         assert_file_grp_cardinality(self.output_file_grp, 1)
 
@@ -70,7 +66,7 @@ class TesserocrCrop(Processor):
             for (n, input_file) in enumerate(self.input_files):
                 file_id = make_file_id(input_file, self.output_file_grp)
                 page_id = input_file.pageId or input_file.ID
-                LOG.info("INPUT FILE %i / %s", n, page_id)
+                self.logger.info("INPUT FILE %i / %s", n, page_id)
                 pcgts = page_from_file(self.workspace.download_file(input_file))
                 self.add_metadata(pcgts)
                 page = pcgts.get_Page()
@@ -79,8 +75,8 @@ class TesserocrCrop(Processor):
                 border = page.get_Border()
                 if border:
                     left, top, right, bottom = bbox_from_points(border.get_Coords().points)
-                    LOG.warning('Overwriting existing Border: %i:%i,%i:%i',
-                                left, top, right, bottom)
+                    self.logger.warning('Overwriting existing Border: %i:%i,%i:%i',
+                                        left, top, right, bottom)
                 
                 page_image, page_xywh, page_image_info = self.workspace.image_from_page(
                     page, page_id,
@@ -89,15 +85,15 @@ class TesserocrCrop(Processor):
                     feature_filter='cropped')
                 if self.parameter['dpi'] > 0:
                     dpi = self.parameter['dpi']
-                    LOG.info("Page '%s' images will use %d DPI from parameter override", page_id, dpi)
+                    self.logger.info("Page '%s' images will use %d DPI from parameter override", page_id, dpi)
                 elif page_image_info.resolution != 1:
                     dpi = page_image_info.resolution
                     if page_image_info.resolutionUnit == 'cm':
                         dpi = round(dpi * 2.54)
-                    LOG.info("Page '%s' images will use %d DPI from image meta-data", page_id, dpi)
+                    self.logger.info("Page '%s' images will use %d DPI from image meta-data", page_id, dpi)
                 else:
                     dpi = 0
-                    LOG.info("Page '%s' images will use DPI estimated from segmentation", page_id)
+                    self.logger.info("Page '%s' images will use DPI estimated from segmentation", page_id)
                 tessapi.SetVariable('user_defined_dpi', str(dpi))
                 if dpi:
                     zoom = 300 / dpi
@@ -119,12 +115,11 @@ class TesserocrCrop(Processor):
         
     def estimate_bounds(self, page, page_image, tessapi, zoom=1.0):
         """Get outer bounds of all (existing or detected) regions."""
-        LOG = getLogger('processor.TesserocrCrop')
         all_left = page_image.width
         all_top = page_image.height
         all_right = 0
         all_bottom = 0
-        LOG.info("Cropping with Tesseract")
+        self.logger.info("Cropping with Tesseract")
         tessapi.SetImage(page_image)
         # PSM.SPARSE_TEXT: get as much text as possible in no particular order
         # PSM.AUTO (default): includes tables (dangerous)
@@ -140,23 +135,23 @@ class TesserocrCrop(Processor):
             #
             ID = "region%04d" % index
             left, top, right, bottom = bbox_from_xywh(xywh)
-            LOG.debug("Detected text region '%s': %i:%i,%i:%i",
-                      ID, left, right, top, bottom)
+            self.logger.debug("Detected text region '%s': %i:%i,%i:%i",
+                              ID, left, right, top, bottom)
             # filter region results:
             bin_bbox = image.getbbox()
             if not bin_bbox:
                 # this does happen!
-                LOG.info("Ignoring region '%s' because its binarization is empty", ID)
+                self.logger.info("Ignoring region '%s' because its binarization is empty", ID)
                 continue
             width = bin_bbox[2]-bin_bbox[0]
             if width < 25 / zoom:
                 # we must be conservative here: page numbers are tiny regions, too!
-                LOG.info("Ignoring region '%s' because its width is too small (%d)", ID, width)
+                self.logger.info("Ignoring region '%s' because its width is too small (%d)", ID, width)
                 continue
             height = bin_bbox[3]-bin_bbox[1]
             if height < 25 / zoom:
                 # we must be conservative here: page numbers are tiny regions, too!
-                LOG.debug("Ignoring region '%s' because its height is too small (%d)", ID, height)
+                self.logger.debug("Ignoring region '%s' because its height is too small (%d)", ID, height)
                 continue
             all_left = min(all_left, left)
             all_top = min(all_top, top)
@@ -166,22 +161,21 @@ class TesserocrCrop(Processor):
         regions = page.get_AllRegions(classes=['Text'])
         for region in regions:
             left, top, right, bottom = bbox_from_points(region.get_Coords().points)
-            LOG.debug("Found existing text region '%s': %i:%i,%i:%i",
-                      region.id, left, right, top, bottom)
+            self.logger.debug("Found existing text region '%s': %i:%i,%i:%i",
+                              region.id, left, right, top, bottom)
             all_left = min(all_left, left)
             all_top = min(all_top, top)
             all_right = max(all_right, right)
             all_bottom = max(all_bottom, bottom)
-        LOG.info("Combined page bounds from text regions: %i:%i,%i:%i",
-                 all_left, all_right, all_top, all_bottom)
+        self.logger.info("Combined page bounds from text regions: %i:%i,%i:%i",
+                         all_left, all_right, all_top, all_bottom)
         return all_left, all_top, all_right, all_bottom
 
     def process_page(self, page, page_image, page_xywh, bounds, file_id, page_id):
         """Set the identified page border, if valid."""
-        LOG = getLogger('processor.TesserocrCrop')
         left, top, right, bottom = bounds
         if left >= right or top >= bottom:
-            LOG.error("Cannot find valid extent for page '%s'", page_id)
+            self.logger.error("Cannot find valid extent for page '%s'", page_id)
             return
         padding = self.parameter['padding']
         # add padding:
@@ -189,12 +183,12 @@ class TesserocrCrop(Processor):
         right = min(right + padding, page_image.width)
         top = max(top - padding, 0)
         bottom = min(bottom + padding, page_image.height)
-        LOG.info("Padded page border: %i:%i,%i:%i", left, right, top, bottom)
+        self.logger.info("Padded page border: %i:%i,%i:%i", left, right, top, bottom)
         polygon = polygon_from_bbox(left, top, right, bottom)
         polygon = coordinates_for_segment(polygon, page_image, page_xywh)
         polygon = polygon_for_parent(polygon, page)
         if polygon is None:
-            LOG.error("Ignoring extant border")
+            self.logger.error("Ignoring extant border")
             return
         border = BorderType(Coords=CoordsType(
             points_from_polygon(polygon)))

--- a/ocrd_tesserocr/deskew.py
+++ b/ocrd_tesserocr/deskew.py
@@ -32,9 +32,6 @@ TOOL = 'ocrd-tesserocr-deskew'
 class TesserocrDeskew(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
-        # workaround for core#998
-        if kwargs['ocrd_tool'] is None:
-            kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         super().__init__(*args, **kwargs)
         if hasattr(self, 'parameter'):
             self.logger = getLogger('processor.TesserocrDeskew')

--- a/ocrd_tesserocr/deskew.py
+++ b/ocrd_tesserocr/deskew.py
@@ -32,6 +32,9 @@ TOOL = 'ocrd-tesserocr-deskew'
 class TesserocrDeskew(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
+        # workaround for core#998
+        if kwargs['ocrd_tool'] is None:
+            kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         super().__init__(*args, **kwargs)
         if hasattr(self, 'parameter'):
             self.logger = getLogger('processor.TesserocrDeskew')

--- a/ocrd_tesserocr/deskew.py
+++ b/ocrd_tesserocr/deskew.py
@@ -126,9 +126,9 @@ class TesserocrDeskew(TesserocrRecognize):
                                                       file_id + '_' + region.id + '_' + line.id)
                 
                 self.workspace.add_file(
-                    ID=file_id,
+                    file_id=file_id,
                     file_grp=self.output_file_grp,
-                    pageId=input_file.pageId,
+                    page_id=input_file.pageId,
                     mimetype=MIMETYPE_PAGE,
                     local_filename=os.path.join(self.output_file_grp, file_id + '.xml'),
                     content=to_xml(pcgts))

--- a/ocrd_tesserocr/deskew.py
+++ b/ocrd_tesserocr/deskew.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import os.path
 import math
-from PIL import Image
 from tesserocr import (
     PyTessBaseAPI,
     PSM, OEM,
@@ -15,7 +14,6 @@ from ocrd_utils import (
     getLogger,
     make_file_id,
     assert_file_grp_cardinality,
-    rotate_image, transpose_image,
     membername,
     MIMETYPE_PAGE
 )
@@ -25,7 +23,6 @@ from ocrd_models.ocrd_page import (
     TextLineType, TextRegionType, PageType,
     to_xml
 )
-from ocrd import Processor
 
 from .config import OCRD_TOOL
 from .recognize import TesserocrRecognize

--- a/ocrd_tesserocr/fontshape.py
+++ b/ocrd_tesserocr/fontshape.py
@@ -27,6 +27,9 @@ TOOL = 'ocrd-tesserocr-fontshape'
 class TesserocrFontShape(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
+        # workaround for core#998
+        if kwargs['ocrd_tool'] is None:
+            kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         super().__init__(*args, **kwargs)
         if hasattr(self, 'parameter'):
             self.logger = getLogger('processor.TesserocrFontShape')

--- a/ocrd_tesserocr/fontshape.py
+++ b/ocrd_tesserocr/fontshape.py
@@ -92,9 +92,9 @@ class TesserocrFontShape(TesserocrRecognize):
                 file_id = make_file_id(input_file, self.output_file_grp)
                 pcgts.set_pcGtsId(file_id)
                 self.workspace.add_file(
-                    ID=file_id,
+                    file_id=file_id,
                     file_grp=self.output_file_grp,
-                    pageId=input_file.pageId,
+                    page_id=input_file.pageId,
                     mimetype=MIMETYPE_PAGE,
                     local_filename=os.path.join(self.output_file_grp,
                                                 file_id + '.xml'),

--- a/ocrd_tesserocr/fontshape.py
+++ b/ocrd_tesserocr/fontshape.py
@@ -18,7 +18,6 @@ from ocrd_models.ocrd_page import (
     TextStyleType,
     to_xml)
 from ocrd_modelfactory import page_from_file
-from ocrd import Processor
 
 from .config import OCRD_TOOL
 from .recognize import TesserocrRecognize

--- a/ocrd_tesserocr/fontshape.py
+++ b/ocrd_tesserocr/fontshape.py
@@ -27,9 +27,6 @@ TOOL = 'ocrd-tesserocr-fontshape'
 class TesserocrFontShape(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
-        # workaround for core#998
-        if kwargs['ocrd_tool'] is None:
-            kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         super().__init__(*args, **kwargs)
         if hasattr(self, 'parameter'):
             self.logger = getLogger('processor.TesserocrFontShape')

--- a/ocrd_tesserocr/fontshape.py
+++ b/ocrd_tesserocr/fontshape.py
@@ -21,19 +21,16 @@ from ocrd_modelfactory import page_from_file
 from ocrd import Processor
 
 from .config import OCRD_TOOL
+from .recognize import TesserocrRecognize
 
 TOOL = 'ocrd-tesserocr-fontshape'
 
-class TesserocrFontShape(Processor):
-
+class TesserocrFontShape(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
-        kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
-        kwargs['version'] = OCRD_TOOL['version']
-        super(TesserocrFontShape, self).__init__(*args, **kwargs)
-
-    @property
-    def moduledir(self):
-        return get_languages()[0]
+        kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
+        super().__init__(*args, **kwargs)
+        if hasattr(self, 'parameter'):
+            self.logger = getLogger('processor.TesserocrFontShape')
 
     def process(self):
         """Detect font shapes via rule-based OCR with Tesseract on the workspace.
@@ -50,8 +47,7 @@ class TesserocrFontShape(Processor):
         
         Produce new output files by serialising the resulting hierarchy.
         """
-        LOG = getLogger('processor.TesserocrFontShape')
-        LOG.debug("TESSDATA: %s, installed Tesseract models: %s", *get_languages())
+        self.logger.debug("TESSDATA: %s, installed Tesseract models: %s", *get_languages())
 
         assert_file_grp_cardinality(self.input_file_grp, 1)
         assert_file_grp_cardinality(self.output_file_grp, 1)
@@ -63,11 +59,11 @@ class TesserocrFontShape(Processor):
         with PyTessBaseAPI(#oem=OEM.TESSERACT_LSTM_COMBINED, # legacy required for OSD or WordFontAttributes!
                            oem=OEM.TESSERACT_ONLY, # legacy required for OSD or WordFontAttributes!
                            lang=model) as tessapi:
-            LOG.info("Using model '%s' in %s for recognition at the word level",
-                     model, get_languages()[0])
+            self.logger.info("Using model '%s' in %s for recognition at the word level",
+                             model, get_languages()[0])
             for (n, input_file) in enumerate(self.input_files):
                 page_id = input_file.pageId or input_file.ID
-                LOG.info("INPUT FILE %i / %s", n, page_id)
+                self.logger.info("INPUT FILE %i / %s", n, page_id)
                 pcgts = page_from_file(self.workspace.download_file(input_file))
                 self.add_metadata(pcgts)
                 page = pcgts.get_Page()
@@ -76,21 +72,21 @@ class TesserocrFontShape(Processor):
                     page, page_id)
                 if self.parameter['dpi'] > 0:
                     dpi = self.parameter['dpi']
-                    LOG.info("Page '%s' images will use %d DPI from parameter override", page_id, dpi)
+                    self.logger.info("Page '%s' images will use %d DPI from parameter override", page_id, dpi)
                 elif page_image_info.resolution != 1:
                     dpi = page_image_info.resolution
                     if page_image_info.resolutionUnit == 'cm':
                         dpi = round(dpi * 2.54)
-                    LOG.info("Page '%s' images will use %d DPI from image meta-data", page_id, dpi)
+                    self.logger.info("Page '%s' images will use %d DPI from image meta-data", page_id, dpi)
                 else:
                     dpi = 0
-                    LOG.info("Page '%s' images will use DPI estimated from segmentation", page_id)
+                    self.logger.info("Page '%s' images will use DPI estimated from segmentation", page_id)
                 tessapi.SetVariable('user_defined_dpi', str(dpi))
                 
-                LOG.info("Processing page '%s'", page_id)
+                self.logger.info("Processing page '%s'", page_id)
                 regions = page.get_AllRegions(classes=['Text'])
                 if not regions:
-                    LOG.warning("Page '%s' contains no text regions", page_id)
+                    self.logger.warning("Page '%s' contains no text regions", page_id)
                 else:
                     self._process_regions(tessapi, regions, page_image, page_coords)
                 
@@ -106,30 +102,27 @@ class TesserocrFontShape(Processor):
                     content=to_xml(pcgts))
 
     def _process_regions(self, tessapi, regions, page_image, page_coords):
-        LOG = getLogger('processor.TesserocrFontShape')
         for region in regions:
             region_image, region_coords = self.workspace.image_from_segment(
                 region, page_image, page_coords)
             textlines = region.get_TextLine()
             if not textlines:
-                LOG.warning("Region '%s' contains no text lines", region.id)
+                self.logger.warning("Region '%s' contains no text lines", region.id)
             else:
                 self._process_lines(tessapi, textlines, region_image, region_coords)
 
     def _process_lines(self, tessapi, textlines, region_image, region_coords):
-        LOG = getLogger('processor.TesserocrFontShape')
         for line in textlines:
             line_image, line_coords = self.workspace.image_from_segment(
                 line, region_image, region_coords)
-            LOG.debug("Recognizing text in line '%s'", line.id)
+            self.logger.debug("Recognizing text in line '%s'", line.id)
             words = line.get_Word()
             if not words:
-                LOG.warning("Line '%s' contains no words", line.id)
+                self.logger.warning("Line '%s' contains no words", line.id)
             else:
                 self._process_words(tessapi, words, line_image, line_coords)
 
     def _process_words(self, tessapi, words, line_image, line_coords):
-        LOG = getLogger('processor.TesserocrFontShape')
         for word in words:
             word_image, word_coords = self.workspace.image_from_segment(
                 word, line_image, line_coords)
@@ -142,19 +135,19 @@ class TesserocrFontShape(Processor):
             tessapi.Recognize()
             result_it = tessapi.GetIterator()
             if not result_it or result_it.Empty(RIL.WORD):
-                LOG.warning("No text in word '%s'", word.id)
+                self.logger.warning("No text in word '%s'", word.id)
                 continue
-            LOG.debug("Decoding text in word '%s'", word.id)
+            self.logger.debug("Decoding text in word '%s'", word.id)
             # trigger recognition
             word_text = result_it.GetUTF8Text(RIL.WORD)
-            LOG.debug('Word "%s" detected "%s"', word.id, word_text)
+            self.logger.debug('Word "%s" detected "%s"', word.id, word_text)
             textequiv = word.get_TextEquiv()
             if textequiv:
-                LOG.info('Word "%s" annotated "%s" / detected "%s"',
-                         word.id, textequiv[0].Unicode, word_text)
+                self.logger.info('Word "%s" annotated "%s" / detected "%s"',
+                                 word.id, textequiv[0].Unicode, word_text)
             word_attributes = result_it.WordFontAttributes()
             if word_attributes:
-                #LOG.debug("found font attributes: {}".format(word_attributes))
+                #self.logger.debug("found font attributes: {}".format(word_attributes))
                 word_style = TextStyleType(
                     fontSize=word_attributes['pointsize']
                     if 'pointsize' in word_attributes else None,

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -1444,6 +1444,10 @@ def join_segments(segments):
 
 def join_polygons(polygons, scale=20):
     """construct concave hull (alpha shape) from input polygons by connecting their pairwise nearest points"""
+    return make_join([Polygon(poly) for poly in polygons], scale=scale).exterior.coords[:-1]
+
+def make_join(polygons, scale=20):
+    """construct concave hull (alpha shape) from input polygons by connecting their pairwise nearest points"""
     # ensure input polygons are simply typed
     polygons = list(itertools.chain.from_iterable([
         poly.geoms if poly.geom_type in ['MultiPolygon', 'GeometryCollection']
@@ -1538,7 +1542,7 @@ def make_intersection(poly1, poly2):
         interp = unary_union([geom for geom in interp.geoms if geom.area > 0])
     if interp.geom_type == 'MultiPolygon':
         # homogeneous result: construct convex hull to connect
-        interp = join_polygons(interp.geoms)
+        interp = make_join(interp.geoms)
     if interp.minimum_clearance < 1.0:
         # follow-up calculations will necessarily be integer;
         # so anticipate rounding here and then ensure validity

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -1444,7 +1444,7 @@ def join_polygons(polygons, scale=20):
     """construct concave hull (alpha shape) from input polygons by connecting their pairwise nearest points"""
     # ensure input polygons are simply typed
     polygons = list(itertools.chain.from_iterable([
-        poly.geoms if poly.type in ['MultiPolygon', 'GeometryCollection']
+        poly.geoms if poly.geom_type in ['MultiPolygon', 'GeometryCollection']
         else [poly]
         for poly in polygons]))
     npoly = len(polygons)
@@ -1468,7 +1468,7 @@ def join_polygons(polygons, scale=20):
         bridgep = LineString(nearest).buffer(max(1, scale/5), resolution=1)
         polygons.append(bridgep)
     jointp = unary_union(polygons)
-    assert jointp.type == 'Polygon', jointp.wkt
+    assert jointp.geom_type == 'Polygon', jointp.wkt
     if jointp.minimum_clearance < 1.0:
         # follow-up calculations will necessarily be integer;
         # so anticipate rounding here and then ensure validity
@@ -1531,10 +1531,10 @@ def make_intersection(poly1, poly2):
         # outside of the valid Border of a deskewed/cropped page
         # (empty corners created by masking); will be ignored
         return None
-    if interp.type == 'GeometryCollection':
+    if interp.geom_type == 'GeometryCollection':
         # heterogeneous result: filter zero-area shapes (LineString, Point)
         interp = unary_union([geom for geom in interp.geoms if geom.area > 0])
-    if interp.type == 'MultiPolygon':
+    if interp.geom_type == 'MultiPolygon':
         # homogeneous result: construct convex hull to connect
         interp = join_polygons(interp.geoms)
     if interp.minimum_clearance < 1.0:

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -459,8 +459,8 @@ class TesserocrRecognize(Processor):
                     self._process_existing_regions(tessapi, regions, page_image, page_coords, pcgts_mapping)
                 else:
                     self.logger.warning("Page '%s' contains no text regions (but segmentation is off)",
-                                            page_id)
-                
+                                        page_id)
+
                 # post-processing
                 # bottom-up text concatenation
                 if outlevel != 'none' and self.parameter.get('model', ''):
@@ -468,14 +468,14 @@ class TesserocrRecognize(Processor):
                 # bottom-up polygonal outline projection
                 # if inlevel != 'none' and self.parameter['shrink_polygons']:
                 #     page_shrink_higher_coordinate_levels(inlevel, outlevel, pcgts)
-                
+
                 self.workspace.add_file(
-                    ID=file_id,
+                    file_id=file_id,
                     file_grp=self.output_file_grp,
-                    pageId=input_file.pageId,
+                    page_id=input_file.pageId,
                     mimetype=MIMETYPE_PAGE,
                     local_filename=join(self.output_file_grp,
-                                                file_id + '.xml'),
+                                        file_id + '.xml'),
                     content=to_xml(pcgts))
 
     def _process_regions_in_page(self, result_it, page, page_coords, mapping, dpi):
@@ -1215,7 +1215,7 @@ class TesserocrRecognize(Processor):
                             for name, val in params.items():
                                 tessapi.SetVariable(name, val)
                 else:
-                    self.logger.error("Cannot find segment '%s' in etree mapping, " \
+                    self.logger.error("Cannot find segment '%s' in etree mapping, "
                                       "ignoring xpath_parameters", ident)
             if self.parameter['xpath_model']:
                 if node is not None and node.attrib.get(at_ident, None) == ident:
@@ -1234,7 +1234,7 @@ class TesserocrRecognize(Processor):
                         tessapi.Reset(lang=model)
                         return
                 else:
-                    self.logger.error("Cannot find segment '%s' in etree mapping, " \
+                    self.logger.error("Cannot find segment '%s' in etree mapping, "
                                       "ignoring xpath_model", ident)
             if self.parameter['auto_model']:
                 models = self.parameter['model'].split('+')
@@ -1392,7 +1392,7 @@ def page_update_higher_textequiv_levels(level, pcgts, overwrite=True):
                     for line, next_line in zip(lines, lines[1:]):
                         words = line.get_Word()
                         next_words = next_line.get_Word()
-                        if not(words and next_words and (words[-1].id, next_words[0].id) in joins):
+                        if not (words and next_words and (words[-1].id, next_words[0].id) in joins):
                             region_unicode += '\n'
                         region_unicode += page_element_unicode0(next_line)
                     region_conf = sum(page_element_conf0(line) for line in lines)

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -126,9 +126,6 @@ class TessBaseAPI(PyTessBaseAPI):
 class TesserocrRecognize(Processor):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
-        # workaround for core#998
-        if kwargs['ocrd_tool'] is None:
-            kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         kwargs.setdefault('version', OCRD_TOOL['version'] + ' (' + tesseract_version().split('\n')[0] + ')')
         super().__init__(*args, **kwargs)
         if hasattr(self, 'parameter'):

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -127,14 +127,11 @@ class TessBaseAPI(PyTessBaseAPI):
         return None
 
 class TesserocrRecognize(Processor):
-
     def __init__(self, *args, **kwargs):
-        kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
-        kwargs['version'] = OCRD_TOOL['version'] + ' (' + tesseract_version().split('\n')[0] + ')'
-
-        super(TesserocrRecognize, self).__init__(*args, **kwargs)
-        
-        if hasattr(self, 'workspace'):
+        kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
+        kwargs.setdefault('version', OCRD_TOOL['version'] + ' (' + tesseract_version().split('\n')[0] + ')')
+        super().__init__(*args, **kwargs)
+        if hasattr(self, 'parameter'):
             self.logger = getLogger('processor.TesserocrRecognize')
 
     @property

--- a/ocrd_tesserocr/recognize.py
+++ b/ocrd_tesserocr/recognize.py
@@ -126,6 +126,9 @@ class TessBaseAPI(PyTessBaseAPI):
 class TesserocrRecognize(Processor):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
+        # workaround for core#998
+        if kwargs['ocrd_tool'] is None:
+            kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         kwargs.setdefault('version', OCRD_TOOL['version'] + ' (' + tesseract_version().split('\n')[0] + ')')
         super().__init__(*args, **kwargs)
         if hasattr(self, 'parameter'):

--- a/ocrd_tesserocr/segment.py
+++ b/ocrd_tesserocr/segment.py
@@ -12,6 +12,9 @@ BASE_TOOL = 'ocrd-tesserocr-recognize'
 class TesserocrSegment(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
+        # workaround for core#998
+        if kwargs['ocrd_tool'] is None:
+            kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         super().__init__(*args, **kwargs)
         if hasattr(self, 'parameter'):
             self.parameter['overwrite_segments'] = True

--- a/ocrd_tesserocr/segment.py
+++ b/ocrd_tesserocr/segment.py
@@ -12,9 +12,6 @@ BASE_TOOL = 'ocrd-tesserocr-recognize'
 class TesserocrSegment(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
-        # workaround for core#998
-        if kwargs['ocrd_tool'] is None:
-            kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         super().__init__(*args, **kwargs)
         if hasattr(self, 'parameter'):
             self.parameter['overwrite_segments'] = True

--- a/ocrd_tesserocr/segment.py
+++ b/ocrd_tesserocr/segment.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 from ocrd_utils import getLogger
-from ocrd import Processor
 from ocrd_validators import ParameterValidator
 
 from .config import OCRD_TOOL

--- a/ocrd_tesserocr/segment.py
+++ b/ocrd_tesserocr/segment.py
@@ -2,34 +2,27 @@ from __future__ import absolute_import
 
 from ocrd_utils import getLogger
 from ocrd import Processor
+from ocrd_validators import ParameterValidator
 
 from .config import OCRD_TOOL
 from .recognize import TesserocrRecognize
 
 TOOL = 'ocrd-tesserocr-segment'
+BASE_TOOL = 'ocrd-tesserocr-recognize'
 
-class TesserocrSegment(Processor):
-
+class TesserocrSegment(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
-        kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
-        kwargs['version'] = OCRD_TOOL['version']
+        kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
         super().__init__(*args, **kwargs)
+        if hasattr(self, 'parameter'):
+            self.parameter['overwrite_segments'] = True
+            self.parameter['segmentation_level'] = "region"
+            self.parameter['textequiv_level'] = "none"
+            # add default params
+            assert ParameterValidator(OCRD_TOOL['tools'][BASE_TOOL]).validate(self.parameter).is_valid
+            self.logger = getLogger('processor.TesserocrSegment')
 
-        if hasattr(self, 'workspace'):
-            recognize_kwargs = {**kwargs}
-            recognize_kwargs.pop('dump_json', None)
-            recognize_kwargs.pop('dump_module_dir', None)
-            recognize_kwargs.pop('show_help', None)
-            recognize_kwargs.pop('show_version', None)
-            recognize_kwargs['parameter'] = self.parameter
-            recognize_kwargs['parameter']['overwrite_segments'] = True
-            recognize_kwargs['parameter']['segmentation_level'] = "region"
-            recognize_kwargs['parameter']['textequiv_level'] = "none"
-            self.recognizer = TesserocrRecognize(self.workspace, **recognize_kwargs)
-            self.recognizer.logger = getLogger('processor.TesserocrSegment')
-
-    def process(self):
-        """Performs region and line segmentation with Tesseract on the workspace.
+TesserocrSegment.process.__doc__ = """Performs region and line segmentation with Tesseract on the workspace.
         
         Open and deserialize PAGE input files and their respective images,
         and remove any existing Region and ReadingOrder elements.
@@ -66,4 +59,3 @@ class TesserocrSegment(Processor):
         
         Produce a new output file by serialising the resulting hierarchy.
         """
-        return self.recognizer.process()

--- a/ocrd_tesserocr/segment_line.py
+++ b/ocrd_tesserocr/segment_line.py
@@ -12,6 +12,9 @@ BASE_TOOL = 'ocrd-tesserocr-recognize'
 class TesserocrSegmentLine(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
+        # workaround for core#998
+        if kwargs['ocrd_tool'] is None:
+            kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         super().__init__(*args, **kwargs)
         if hasattr(self, 'parameter'):
             self.parameter['overwrite_segments'] = self.parameter['overwrite_lines']

--- a/ocrd_tesserocr/segment_line.py
+++ b/ocrd_tesserocr/segment_line.py
@@ -12,9 +12,6 @@ BASE_TOOL = 'ocrd-tesserocr-recognize'
 class TesserocrSegmentLine(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
-        # workaround for core#998
-        if kwargs['ocrd_tool'] is None:
-            kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         super().__init__(*args, **kwargs)
         if hasattr(self, 'parameter'):
             self.parameter['overwrite_segments'] = self.parameter['overwrite_lines']

--- a/ocrd_tesserocr/segment_line.py
+++ b/ocrd_tesserocr/segment_line.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 from ocrd_utils import getLogger
-from ocrd import Processor
 from ocrd_validators import ParameterValidator
 
 from .config import OCRD_TOOL

--- a/ocrd_tesserocr/segment_region.py
+++ b/ocrd_tesserocr/segment_region.py
@@ -12,6 +12,9 @@ BASE_TOOL = 'ocrd-tesserocr-recognize'
 class TesserocrSegmentRegion(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
+        # workaround for core#998
+        if kwargs['ocrd_tool'] is None:
+            kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         super().__init__(*args, **kwargs)
         if hasattr(self, 'parameter'):
             self.parameter['overwrite_segments'] = self.parameter['overwrite_regions']

--- a/ocrd_tesserocr/segment_region.py
+++ b/ocrd_tesserocr/segment_region.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 from ocrd_utils import getLogger
-from ocrd import Processor
 from ocrd_validators import ParameterValidator
 
 from .config import OCRD_TOOL

--- a/ocrd_tesserocr/segment_region.py
+++ b/ocrd_tesserocr/segment_region.py
@@ -2,37 +2,30 @@ from __future__ import absolute_import
 
 from ocrd_utils import getLogger
 from ocrd import Processor
+from ocrd_validators import ParameterValidator
 
 from .config import OCRD_TOOL
 from .recognize import TesserocrRecognize
 
 TOOL = 'ocrd-tesserocr-segment-region'
+BASE_TOOL = 'ocrd-tesserocr-recognize'
 
-class TesserocrSegmentRegion(Processor):
-
+class TesserocrSegmentRegion(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
-        kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
-        kwargs['version'] = OCRD_TOOL['version']
+        kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
         super().__init__(*args, **kwargs)
-        
-        if hasattr(self, 'workspace'):
-            recognize_kwargs = {**kwargs}
-            recognize_kwargs.pop('dump_json', None)
-            recognize_kwargs.pop('dump_module_dir', None)
-            recognize_kwargs.pop('show_help', None)
-            recognize_kwargs.pop('show_version', None)
-            recognize_kwargs['parameter'] = self.parameter
-            recognize_kwargs['parameter']['overwrite_segments'] = self.parameter['overwrite_regions']
-            del recognize_kwargs['parameter']['overwrite_regions']
-            recognize_kwargs['parameter']['segmentation_level'] = "region"
-            recognize_kwargs['parameter']['textequiv_level'] = "region"
-            recognize_kwargs['parameter']['block_polygons'] = self.parameter['crop_polygons']
-            del recognize_kwargs['parameter']['crop_polygons']
-            self.recognizer = TesserocrRecognize(self.workspace, **recognize_kwargs)
-            self.recognizer.logger = getLogger('processor.TesserocrSegmentRegion')
+        if hasattr(self, 'parameter'):
+            self.parameter['overwrite_segments'] = self.parameter['overwrite_regions']
+            del self.parameter['overwrite_regions']
+            self.parameter['segmentation_level'] = "region"
+            self.parameter['textequiv_level'] = "region"
+            self.parameter['block_polygons'] = self.parameter['crop_polygons']
+            del self.parameter['crop_polygons']
+            # add default params
+            assert ParameterValidator(OCRD_TOOL['tools'][BASE_TOOL]).validate(self.parameter).is_valid
+            self.logger = getLogger('processor.TesserocrSegmentRegion')
 
-    def process(self):
-        """Performs region segmentation with Tesseract on the workspace.
+TesserocrSegmentRegion.process.__doc__ = """Performs region segmentation with Tesseract on the workspace.
         
         Open and deserialize PAGE input files and their respective images,
         and remove any existing Region and ReadingOrder elements
@@ -56,4 +49,3 @@ class TesserocrSegmentRegion(Processor):
         
         Produce a new output file by serialising the resulting hierarchy.
         """
-        return self.recognizer.process()

--- a/ocrd_tesserocr/segment_region.py
+++ b/ocrd_tesserocr/segment_region.py
@@ -12,9 +12,6 @@ BASE_TOOL = 'ocrd-tesserocr-recognize'
 class TesserocrSegmentRegion(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
-        # workaround for core#998
-        if kwargs['ocrd_tool'] is None:
-            kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         super().__init__(*args, **kwargs)
         if hasattr(self, 'parameter'):
             self.parameter['overwrite_segments'] = self.parameter['overwrite_regions']

--- a/ocrd_tesserocr/segment_table.py
+++ b/ocrd_tesserocr/segment_table.py
@@ -12,6 +12,9 @@ BASE_TOOL = 'ocrd-tesserocr-recognize'
 class TesserocrSegmentTable(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
+        # workaround for core#998
+        if kwargs['ocrd_tool'] is None:
+            kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         super().__init__(*args, **kwargs)
         if hasattr(self, 'parameter'):
             self.parameter['overwrite_segments'] = self.parameter['overwrite_cells']

--- a/ocrd_tesserocr/segment_table.py
+++ b/ocrd_tesserocr/segment_table.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 from ocrd_utils import getLogger
-from ocrd import Processor
 from ocrd_validators import ParameterValidator
 
 from .config import OCRD_TOOL

--- a/ocrd_tesserocr/segment_table.py
+++ b/ocrd_tesserocr/segment_table.py
@@ -2,35 +2,28 @@ from __future__ import absolute_import
 
 from ocrd_utils import getLogger
 from ocrd import Processor
+from ocrd_validators import ParameterValidator
 
 from .config import OCRD_TOOL
 from .recognize import TesserocrRecognize
 
 TOOL = 'ocrd-tesserocr-segment-table'
+BASE_TOOL = 'ocrd-tesserocr-recognize'
 
-class TesserocrSegmentTable(Processor):
-
+class TesserocrSegmentTable(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
-        kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
-        kwargs['version'] = OCRD_TOOL['version']
+        kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
         super().__init__(*args, **kwargs)
-        
-        if hasattr(self, 'workspace'):
-            recognize_kwargs = {**kwargs}
-            recognize_kwargs.pop('dump_json', None)
-            recognize_kwargs.pop('dump_module_dir', None)
-            recognize_kwargs.pop('show_help', None)
-            recognize_kwargs.pop('show_version', None)
-            recognize_kwargs['parameter'] = self.parameter
-            recognize_kwargs['parameter']['overwrite_segments'] = self.parameter['overwrite_cells']
-            del recognize_kwargs['parameter']['overwrite_regions']
-            recognize_kwargs['parameter']['segmentation_level'] = "cell"
-            recognize_kwargs['parameter']['textequiv_level'] = "cell"
-            self.recognizer = TesserocrRecognize(self.workspace, **recognize_kwargs)
-            self.recognizer.logger = getLogger('processor.TesserocrSegmentTable')
+        if hasattr(self, 'parameter'):
+            self.parameter['overwrite_segments'] = self.parameter['overwrite_cells']
+            del self.parameter['overwrite_cells']
+            self.parameter['segmentation_level'] = "cell"
+            self.parameter['textequiv_level'] = "cell"
+            # add default params
+            assert ParameterValidator(OCRD_TOOL['tools'][BASE_TOOL]).validate(self.parameter).is_valid
+            self.logger = getLogger('processor.TesserocrSegmentTable')
 
-    def process(self):
-        """Performs table cell segmentation with Tesseract on the workspace.
+TesserocrSegmentTable.process.__doc__ = """Performs table cell segmentation with Tesseract on the workspace.
         
         Open and deserialize PAGE input files and their respective images,
         then iterate over the element hierarchy down to the region level
@@ -44,4 +37,3 @@ class TesserocrSegmentTable(Processor):
         
         Produce a new output file by serialising the resulting hierarchy.
         """
-        return self.recognizer.process()

--- a/ocrd_tesserocr/segment_table.py
+++ b/ocrd_tesserocr/segment_table.py
@@ -12,9 +12,6 @@ BASE_TOOL = 'ocrd-tesserocr-recognize'
 class TesserocrSegmentTable(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
-        # workaround for core#998
-        if kwargs['ocrd_tool'] is None:
-            kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         super().__init__(*args, **kwargs)
         if hasattr(self, 'parameter'):
             self.parameter['overwrite_segments'] = self.parameter['overwrite_cells']

--- a/ocrd_tesserocr/segment_word.py
+++ b/ocrd_tesserocr/segment_word.py
@@ -12,6 +12,9 @@ BASE_TOOL = 'ocrd-tesserocr-recognize'
 class TesserocrSegmentWord(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
+        # workaround for core#998
+        if kwargs['ocrd_tool'] is None:
+            kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         super().__init__(*args, **kwargs)
         if hasattr(self, 'parameter'):
             self.parameter['overwrite_segments'] = self.parameter['overwrite_words']

--- a/ocrd_tesserocr/segment_word.py
+++ b/ocrd_tesserocr/segment_word.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 from ocrd_utils import getLogger
-from ocrd import Processor
 from ocrd_validators import ParameterValidator
 
 from .config import OCRD_TOOL

--- a/ocrd_tesserocr/segment_word.py
+++ b/ocrd_tesserocr/segment_word.py
@@ -12,9 +12,6 @@ BASE_TOOL = 'ocrd-tesserocr-recognize'
 class TesserocrSegmentWord(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
-        # workaround for core#998
-        if kwargs['ocrd_tool'] is None:
-            kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
         super().__init__(*args, **kwargs)
         if hasattr(self, 'parameter'):
             self.parameter['overwrite_segments'] = self.parameter['overwrite_words']

--- a/ocrd_tesserocr/segment_word.py
+++ b/ocrd_tesserocr/segment_word.py
@@ -2,35 +2,28 @@ from __future__ import absolute_import
 
 from ocrd_utils import getLogger
 from ocrd import Processor
+from ocrd_validators import ParameterValidator
 
 from .config import OCRD_TOOL
 from .recognize import TesserocrRecognize
 
 TOOL = 'ocrd-tesserocr-segment-word'
+BASE_TOOL = 'ocrd-tesserocr-recognize'
 
-class TesserocrSegmentWord(Processor):
-
+class TesserocrSegmentWord(TesserocrRecognize):
     def __init__(self, *args, **kwargs):
-        kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
-        kwargs['version'] = OCRD_TOOL['version']
+        kwargs.setdefault('ocrd_tool', OCRD_TOOL['tools'][TOOL])
         super().__init__(*args, **kwargs)
-        
-        if hasattr(self, 'workspace'):
-            recognize_kwargs = {**kwargs}
-            recognize_kwargs.pop('dump_json', None)
-            recognize_kwargs.pop('dump_module_dir', None)
-            recognize_kwargs.pop('show_help', None)
-            recognize_kwargs.pop('show_version', None)
-            recognize_kwargs['parameter'] = self.parameter
-            recognize_kwargs['parameter']['overwrite_segments'] = self.parameter['overwrite_words']
-            del recognize_kwargs['parameter']['overwrite_words']
-            recognize_kwargs['parameter']['segmentation_level'] = "word"
-            recognize_kwargs['parameter']['textequiv_level'] = "word"
-            self.recognizer = TesserocrRecognize(self.workspace, **recognize_kwargs)
-            self.recognizer.logger = getLogger('processor.TesserocrSegmentWord')
+        if hasattr(self, 'parameter'):
+            self.parameter['overwrite_segments'] = self.parameter['overwrite_words']
+            del self.parameter['overwrite_words']
+            self.parameter['segmentation_level'] = "word"
+            self.parameter['textequiv_level'] = "word"
+            # add default params
+            assert ParameterValidator(OCRD_TOOL['tools'][BASE_TOOL]).validate(self.parameter).is_valid
+            self.logger = getLogger('processor.TesserocrSegmentWord')
 
-    def process(self):
-        """Performs word segmentation with Tesseract on the workspace.
+TesserocrSegmentWord.process.__doc__ = """Performs word segmentation with Tesseract on the workspace.
         
         Open and deserialize PAGE input files and their respective images,
         then iterate over the element hierarchy down to the textline level,
@@ -47,4 +40,3 @@ class TesserocrSegmentWord(Processor):
         
         Produce a new output file by serialising the resulting hierarchy.
         """
-        return self.recognizer.process()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ocrd >= 2.47
+ocrd >= 2.48
 click
 tesserocr >= 2.5.2
 shapely >= 1.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ocrd >= 2.40
+ocrd >= 2.47
 click
 tesserocr >= 2.5.2
 shapely >= 1.7.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,3 @@
 pytest >= 4.4.0
+pytest-xdist
 coverage >= 4.5.2

--- a/test/base.py
+++ b/test/base.py
@@ -2,10 +2,14 @@
 
 import os
 import sys
-from unittest import TestCase, skip, main as unittests_main # pylint: disable=unused-import
+import shutil
+from tempfile import mkdtemp
+from unittest import TestCase as VanillaTestCase, main as unittests_main, skip # pylint: disable=unused-import
 import pytest
 
 from test.assets import assets
+from ocrd.resolver import Resolver
+from ocrd_utils import initLogging
 
 PWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(PWD + '/../ocrd')
@@ -16,7 +20,33 @@ def main(fn=None):
     else:
         unittests_main()
 
-class CapturingTestCase(TestCase):
+class TestCase(VanillaTestCase):
+    METS_HEROLD_SMALL = None
+
+    @classmethod
+    def setUpClass(cls):
+        initLogging()
+
+    # we must intercept and reinstate CWD, because Processor.__init__ does chdir,
+    # but setUp needs to rm that copy afterwards; so the next test would end up
+    # in a non-existing CWD, causing os.getcwd() to fail
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.old_cwd = os.getcwd()
+        self.resolver = Resolver()
+        self.workspace = None
+    def tearDown(self):
+        os.chdir(self.old_cwd)
+        if os.path.exists(self.workspace.directory):
+            shutil.rmtree(self.workspace.directory)
+        self.workspace = None
+    # isolate test methods from each other by cloning the asset workspace afresh
+    def setUp(self):
+        self.workspace = self.resolver.workspace_from_url(
+            self.METS_HEROLD_SMALL, download=True,
+            dst_dir=mkdtemp(prefix=self.__class__.__name__))
+
+class CapturingTestCase(VanillaTestCase):
     """
     A TestCase that needs to capture stderr/stdout and invoke click CLI.
     """

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -2,8 +2,6 @@ from click.testing import CliRunner
 
 from test.base import main
 from pathlib import Path
-from ocrd_utils import pushd_popd
-from ocrd_utils import disableLogging
 
 runner = CliRunner()
 

--- a/test/test_recognize.py
+++ b/test/test_recognize.py
@@ -1,67 +1,156 @@
 import os
-import shutil
-
 from test.base import TestCase, main, assets, skip
 
-from ocrd.resolver import Resolver
+from ocrd_models.constants import NAMESPACES
+from ocrd_modelfactory import page_from_file
+from ocrd_utils import MIMETYPE_PAGE
+from ocrd_tesserocr import TesserocrDeskew
 from ocrd_tesserocr import TesserocrSegmentWord
 from ocrd_tesserocr import TesserocrSegmentLine
 from ocrd_tesserocr import TesserocrSegmentRegion
 from ocrd_tesserocr import TesserocrRecognize
+from ocrd_tesserocr import TesserocrFontShape
 
-#METS_HEROLD_SMALL = assets.url_of('SBB0000F29300010000/data/mets_one_file.xml')
-# as long as #96 remains, we cannot use workspaces which have local relative files:
-METS_HEROLD_SMALL = assets.url_of('kant_aufklaerung_1784-binarized/data/mets.xml')
-
-WORKSPACE_DIR = '/tmp/pyocrd-test-recognizer'
 
 class TestTesserocrRecognize(TestCase):
+    #METS_HEROLD_SMALL = assets.url_of('SBB0000F29300010000/data/mets_one_file.xml')
+    # as long as #96 remains, we cannot use workspaces which have local relative files:
+    METS_HEROLD_SMALL = assets.url_of('kant_aufklaerung_1784-binarized/data/mets.xml')
 
-    def setUp(self):
-        if os.path.exists(WORKSPACE_DIR):
-            shutil.rmtree(WORKSPACE_DIR)
-        os.makedirs(WORKSPACE_DIR)
-
-    #skip("Takes too long")
-    def runTest(self):
-        resolver = Resolver()
-        workspace = resolver.workspace_from_url(METS_HEROLD_SMALL, dst_dir=WORKSPACE_DIR)
+    def test_run_modular(self):
         TesserocrSegmentRegion(
-            workspace,
+            self.workspace,
             input_file_grp="OCR-D-IMG",
             output_file_grp="OCR-D-SEG-BLOCK"
         ).process()
-        workspace.save_mets()
-
         TesserocrSegmentLine(
-            workspace,
+            self.workspace,
             input_file_grp="OCR-D-SEG-BLOCK",
             output_file_grp="OCR-D-SEG-LINE"
         ).process()
-        workspace.save_mets()
-
         TesserocrRecognize(
-            workspace,
+            self.workspace,
             input_file_grp="OCR-D-SEG-LINE",
             output_file_grp="OCR-D-OCR-TESS",
-            parameter={'textequiv_level': 'line'} # add dep tesseract-ocr-script-frak: , 'model': 'Fraktur'
+            parameter={'textequiv_level': 'line', 'model': 'Fraktur'}
         ).process()
-        workspace.save_mets()
-
         TesserocrSegmentWord(
-            workspace,
+            self.workspace,
             input_file_grp="OCR-D-SEG-LINE",
             output_file_grp="OCR-D-SEG-WORD"
         ).process()
-        workspace.save_mets()
-
         TesserocrRecognize(
-            workspace,
+            self.workspace,
             input_file_grp="OCR-D-SEG-WORD",
             output_file_grp="OCR-D-OCR-TESS-W2C",
-            parameter={'textequiv_level': 'glyph'} # add dep tesseract-ocr-script-frak: , 'model': 'Fraktur'}
+            parameter={'segmentation_level': 'glyph', 'textequiv_level': 'glyph', 'model': 'Fraktur'}
         ).process()
-        workspace.save_mets()
+        self.workspace.save_mets()
+        assert os.path.isdir(os.path.join(self.workspace.directory, 'OCR-D-OCR-TESS-W2C'))
+        results = self.workspace.find_files(file_grp='OCR-D-OCR-TESS-W2C', mimetype=MIMETYPE_PAGE)
+        result0 = next(results, False)
+        assert result0
+        _, result0, _, _ = page_from_file(result0, with_tree=True)
+        text0 = result0.xpath('//page:Glyph/page:TextEquiv/page:Unicode', namespaces=NAMESPACES)
+        assert len(text0) > 0
+
+    def test_run_modular_full(self):
+        TesserocrDeskew(
+            self.workspace,
+            input_file_grp="OCR-D-IMG",
+            output_file_grp="OCR-D-DESK",
+            parameter={"operation_level": "page"}
+        ).process()
+        TesserocrSegmentRegion(
+            self.workspace,
+            input_file_grp="OCR-D-DESK",
+            output_file_grp="OCR-D-SEG-BLOCK"
+        ).process()
+        TesserocrDeskew(
+            self.workspace,
+            input_file_grp="OCR-D-SEG-BLOCK",
+            output_file_grp="OCR-D-DESK-BLOCK",
+            parameter={"operation_level": "region"}
+        ).process()
+        TesserocrSegmentLine(
+            self.workspace,
+            input_file_grp="OCR-D-DESK-BLOCK",
+            output_file_grp="OCR-D-SEG-LINE"
+        ).process()
+        TesserocrRecognize(
+            self.workspace,
+            input_file_grp="OCR-D-SEG-LINE",
+            output_file_grp="OCR-D-OCR-TESS",
+            parameter={'textequiv_level': 'word', 'raw_lines': True, 'xpath_model': {'starts-with(@script,"Latn")': 'deu+eng', 'starts-with(@script,"Latf")': 'Fraktur'}, 'model': 'Fraktur+deu+eng'}
+        ).process()
+        TesserocrFontShape(
+            self.workspace,
+            input_file_grp="OCR-D-OCR-TESS",
+            output_file_grp="OCR-D-OCR-STYLE"
+        ).process()
+        self.workspace.save_mets()
+        assert os.path.isdir(os.path.join(self.workspace.directory, 'OCR-D-OCR-STYLE'))
+        results = self.workspace.find_files(file_grp='OCR-D-OCR-STYLE', mimetype=MIMETYPE_PAGE)
+        result0 = next(results, False)
+        assert result0
+        _, result0, _, _ = page_from_file(result0, with_tree=True)
+        text0 = result0.xpath('//page:Word/page:TextEquiv/page:Unicode', namespaces=NAMESPACES)
+        assert len(text0) > 0
+        style0 = result0.xpath('//page:Word/page:TextStyle', namespaces=NAMESPACES)
+        assert len(style0) > 0
+
+    def test_run_allinone(self):
+        TesserocrRecognize(
+            self.workspace,
+            input_file_grp="OCR-D-IMG",
+            output_file_grp="OCR-D-OCR-TESS-W2C",
+            parameter={'segmentation_level': 'region', 'textequiv_level': 'glyph', 'model': 'Fraktur'}
+        ).process()
+        self.workspace.save_mets()
+        assert os.path.isdir(os.path.join(self.workspace.directory, 'OCR-D-OCR-TESS-W2C'))
+        results = self.workspace.find_files(file_grp='OCR-D-OCR-TESS-W2C', mimetype=MIMETYPE_PAGE)
+        result0 = next(results, False)
+        assert result0
+        _, result0, _, _ = page_from_file(result0, with_tree=True)
+        text0 = result0.xpath('//page:Glyph/page:TextEquiv/page:Unicode', namespaces=NAMESPACES)
+        assert len(text0) > 0
+
+    def test_run_allinone_shrink(self):
+        TesserocrRecognize(
+            self.workspace,
+            input_file_grp="OCR-D-IMG",
+            output_file_grp="OCR-D-OCR-TESS-W2C",
+            parameter={'segmentation_level': 'region', 'textequiv_level': 'glyph', 'shrink_polygons': True, 'model': 'Fraktur'}
+        ).process()
+        self.workspace.save_mets()
+
+    def test_run_allinone_sparse(self):
+        TesserocrRecognize(
+            self.workspace,
+            input_file_grp="OCR-D-IMG",
+            output_file_grp="OCR-D-OCR-TESS-W2C",
+            parameter={'segmentation_level': 'region', 'textequiv_level': 'glyph', 'sparse_text': True, 'model': 'Fraktur'}
+        ).process()
+        self.workspace.save_mets()
+
+    def test_run_allineone_multimodel(self):
+        TesserocrRecognize(
+            self.workspace,
+            input_file_grp="OCR-D-IMG",
+            output_file_grp="OCR-D-OCR-TESS-W2C",
+            parameter={'segmentation_level': 'region', 'textequiv_level': 'glyph', 'model': 'Fraktur+eng+deu'}
+        ).process()
+        self.workspace.save_mets()
+
+    # @skip
+    def test_run_allinone_automodel(self):
+        TesserocrRecognize(
+            self.workspace,
+            input_file_grp="OCR-D-IMG",
+            output_file_grp="OCR-D-OCR-TESS-W2C",
+            parameter={'segmentation_level': 'region', 'textequiv_level': 'glyph', 'auto_model': True, 'model': 'Fraktur+eng+deu'}
+        ).process()
+        self.workspace.save_mets()
 
 if __name__ == '__main__':
     main(__file__)

--- a/test/test_segment_line.py
+++ b/test/test_segment_line.py
@@ -1,38 +1,34 @@
 import os
-import shutil
-
 from test.base import TestCase, main, assets
 
-from ocrd.resolver import Resolver
 from ocrd_tesserocr import TesserocrSegmentRegion
 from ocrd_tesserocr import TesserocrSegmentLine
-
-METS_HEROLD_SMALL = assets.url_of('SBB0000F29300010000/data/mets_one_file.xml')
-
-WORKSPACE_DIR = '/tmp/pyocrd-test-segment-line-tesserocr'
+from ocrd_tesserocr import TesserocrSegment
 
 class TestProcessorSegmentLineTesseract(TestCase):
+    METS_HEROLD_SMALL = assets.url_of('SBB0000F29300010000/data/mets_one_file.xml')
 
-    def setUp(self):
-        if os.path.exists(WORKSPACE_DIR):
-            shutil.rmtree(WORKSPACE_DIR)
-        os.makedirs(WORKSPACE_DIR)
-
-    def runTest(self):
-        resolver = Resolver()
-        workspace = resolver.workspace_from_url(METS_HEROLD_SMALL, dst_dir=WORKSPACE_DIR)
+    def test_run_modular(self):
         TesserocrSegmentRegion(
-            workspace,
+            self.workspace,
             input_file_grp="OCR-D-IMG",
             output_file_grp="OCR-D-SEG-BLOCK"
         ).process()
-        #  workspace.save_mets()
+        #  self.workspace.save_mets()
         TesserocrSegmentLine(
-            workspace,
+            self.workspace,
             input_file_grp="OCR-D-SEG-BLOCK",
             output_file_grp="OCR-D-SEG-LINE"
         ).process()
-        workspace.save_mets()
+        self.workspace.save_mets()
+
+    def test_run_allinone(self):
+        TesserocrSegment(
+            self.workspace,
+            input_file_grp="OCR-D-IMG",
+            output_file_grp="OCR-D-SEG"
+        ).process()
+        self.workspace.save_mets()
 
 if __name__ == '__main__':
-    main()
+    main(__file__)

--- a/test/test_segment_region.py
+++ b/test/test_segment_region.py
@@ -1,31 +1,45 @@
 import os
-import shutil
+from test.base import TestCase, main, assets, skip
 
-from test.base import TestCase, main, assets
-
-from ocrd.resolver import Resolver
 from ocrd_tesserocr import TesserocrSegmentRegion
 
-METS_HEROLD_SMALL = assets.url_of('SBB0000F29300010000/data/mets_one_file.xml')
-
-WORKSPACE_DIR = '/tmp/pyocrd-test-segment-region-tesserocr'
-
 class TestTesserocrSegmentRegionTesseract(TestCase):
+    METS_HEROLD_SMALL = assets.url_of('SBB0000F29300010000/data/mets_one_file.xml')
 
-    def setUp(self):
-        if os.path.exists(WORKSPACE_DIR):
-            shutil.rmtree(WORKSPACE_DIR)
-        os.makedirs(WORKSPACE_DIR)
-
-    def runTest(self):
-        resolver = Resolver()
-        workspace = resolver.workspace_from_url(METS_HEROLD_SMALL, dst_dir=WORKSPACE_DIR)
+    def test_run(self):
         TesserocrSegmentRegion(
-            workspace,
+            self.workspace,
             input_file_grp="OCR-D-IMG",
             output_file_grp="OCR-D-SEG-BLOCK"
         ).process()
-        workspace.save_mets()
+        self.workspace.save_mets()
+
+    def test_run_shrink(self):
+        TesserocrSegmentRegion(
+            self.workspace,
+            input_file_grp="OCR-D-IMG",
+            output_file_grp="OCR-D-SEG-BLOCK",
+            parameter={'shrink_polygons': True}
+        ).process()
+        self.workspace.save_mets()
+
+    def test_run_sparse(self):
+        TesserocrSegmentRegion(
+            self.workspace,
+            input_file_grp="OCR-D-IMG",
+            output_file_grp="OCR-D-SEG-BLOCK",
+            parameter={'sparse_text': True}
+        ).process()
+        self.workspace.save_mets()
+
+    def test_run_staves(self):
+        TesserocrSegmentRegion(
+            self.workspace,
+            input_file_grp="OCR-D-IMG",
+            output_file_grp="OCR-D-SEG-BLOCK",
+            parameter={'find_staves': True, 'find_tables': False}
+        ).process()
+        self.workspace.save_mets()
 
 if __name__ == '__main__':
-    main()
+    main(__file__)

--- a/test/test_segment_word.py
+++ b/test/test_segment_word.py
@@ -1,44 +1,31 @@
 import os
-import shutil
-
 from test.base import TestCase, main, assets
 
-from ocrd import Resolver
 from ocrd_tesserocr import TesserocrSegmentRegion
 from ocrd_tesserocr import TesserocrSegmentLine
 from ocrd_tesserocr import TesserocrSegmentWord
 
-#METS_HEROLD_SMALL = assets.url_of('SBB0000F29300010000/mets_one_file.xml')
-METS_HEROLD_SMALL = assets.url_of('kant_aufklaerung_1784-binarized/data/mets.xml')
-
-WORKSPACE_DIR = '/tmp/pyocrd-test-segment-word-tesserocr'
-
 class TestProcessorSegmentWordTesseract(TestCase):
+    #METS_HEROLD_SMALL = assets.url_of('SBB0000F29300010000/mets_one_file.xml')
+    METS_HEROLD_SMALL = assets.url_of('kant_aufklaerung_1784-binarized/data/mets.xml')
 
-    def setUp(self):
-        if os.path.exists(WORKSPACE_DIR):
-            shutil.rmtree(WORKSPACE_DIR)
-        os.makedirs(WORKSPACE_DIR)
-
-    def runTest(self):
-        resolver = Resolver()
-        workspace = resolver.workspace_from_url(METS_HEROLD_SMALL, dst_dir=WORKSPACE_DIR)
+    def test_run_modular(self):
         TesserocrSegmentRegion(
-            workspace,
+            self.workspace,
             input_file_grp="OCR-D-IMG",
             output_file_grp="OCR-D-SEG-BLOCK"
         ).process()
         TesserocrSegmentLine(
-            workspace,
+            self.workspace,
             input_file_grp="OCR-D-SEG-BLOCK",
             output_file_grp="OCR-D-SEG-LINE"
         ).process()
         TesserocrSegmentWord(
-            workspace,
+            self.workspace,
             input_file_grp="OCR-D-SEG-LINE",
             output_file_grp="OCR-D-SEG-WORD"
         ).process()
-        workspace.save_mets()
+        self.workspace.save_mets()
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
fixes #190 

Perhaps we should also add a test case for the workspace mechanics. I have a feeling this should have failed long ago even without the Processing Server's instance caching.