### PR TITLE
Replace libcurl4-nss-dev by libcurl4-openssl-dev (fixes build on Ubuntu 24.04)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ deps-ubuntu:
 		libicu-dev \
 		autotools-dev \
 		automake \
-		libcurl4-nss-dev \
+		libcurl4-openssl-dev \
 		libarchive-dev
 
 # Install Python deps for install via pip


### PR DESCRIPTION
Ubuntu 24.04 no longer provides libcurl4-nss.