### PR TITLE
CircleCI: add CD via PyPI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,9 @@ workflows:
             parameters:
               python-version: ['3.7', '3.8', '3.9', '3.10']
   deploy:
+    when:
+      condition:
+        equal: [ OCR-D/ocrd_tesserocr, << pipeline.trigger_parameters.github_app.repo_name >>]
     jobs:
       - deploy-docker:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,10 @@ jobs:
       - run: sudo make deps-ubuntu
       - run: make install
       - run: make deps-test
-      - run: make test
+      - run: mkdir test-results
+      - run: make test PYTEST_ARGS=--junitxml=test-results/test.xml
+      - store_test_results:
+          path: test-results
       - run: make test-cli
       - run: make coverage
       - codecov/upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ workflows:
               only: master
       - deploy-pypi:
           requires:
-	    - deploy-docker
+            - deploy-docker
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,15 @@ jobs:
           command: echo "$DOCKERHUB_PASS" | docker login --username "$DOCKERHUB_USER" --password-stdin
       - run: docker push $DOCKER_TAG
 
+  deploy-pypi:
+    docker:
+      - image: ocrd/tesserocr
+    steps:
+      - checkout
+      - run: pip install twine build
+      - run: python -m build .
+      - run: twine upload dist/*
+
 
 workflows:
   build:
@@ -53,6 +62,12 @@ workflows:
   deploy:
     jobs:
       - deploy-docker:
+          filters:
+            branches:
+              only: master
+      - deploy-pypi:
+          requires:
+	    - deploy-docker
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ workflows:
   deploy:
     when:
       condition:
-        equal: [ OCR-D/ocrd_tesserocr, << pipeline.trigger_parameters.github_app.repo_name >>]
+        equal: [ https://github.com/OCR-D/ocrd_tesserocr, << pipeline.project.git_url >>]
     jobs:
       - deploy-docker:
           filters:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,7 +6,7 @@ on:
     branches: [ "master" ]
 
 env:
-  IMAGE_NAME: ghcr.io/ocr-d/tesserocr
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
 
 jobs:
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include ocrd-tool.json
+include README.md
+include requirements.txt


### PR DESCRIPTION
Not sure if there is a better way. We cannot use our own Docker image in Github Actions, but in CircleCI we can. (Without that image, I am not sure if the build could succeed without first installing Tesseract and tesserocr.)