### PR TITLE
Fix broken docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,19 @@ jobs:
       - run: make coverage
       - codecov/upload
 
+  build-docker:
+    docker:
+      - image: circleci/buildpack-deps:stretch
+    environment:
+      DOCKER_TAG: ocrd/tesserocr
+    steps:
+      - checkout
+      - run: git submodule sync && git submodule update --init
+      - setup_remote_docker: # https://circleci.com/docs/2.0/building-docker-images/
+          docker_layer_caching: true
+      - run: make docker DOCKER_TAG=$DOCKER_TAG
+      - run: docker run --rm $DOCKER_TAG ocrd-tesserocr-segment -h
+
   deploy-docker:
     docker:
       - image: circleci/buildpack-deps:stretch
@@ -40,6 +53,7 @@ jobs:
       - setup_remote_docker: # https://circleci.com/docs/2.0/building-docker-images/
           docker_layer_caching: true
       - run: make docker DOCKER_TAG=$DOCKER_TAG
+      - run: docker run --rm $DOCKER_TAG ocrd-tesserocr-segment -h
       - run:
           name: Login to Docker Hub
           command: echo "$DOCKERHUB_PASS" | docker login --username "$DOCKERHUB_USER" --password-stdin
@@ -62,6 +76,8 @@ workflows:
           matrix:
             parameters:
               python-version: ['3.7', '3.8', '3.9', '3.10']
+      - build-docker
+
   deploy:
     when:
       condition:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -34,6 +34,8 @@ jobs:
       run: echo "IMAGE_NAME=ghcr.io/${REPO_NAME,,}" >> $GITHUB_ENV
     - name: Build the Docker image
       run: make docker DOCKER_TAG=${{ env.IMAGE_NAME }}
+    - name: Test the Docker image
+      run: docker run --rm ${{ env.IMAGE_NAME }} ocrd-tesserocr-segment -h
     - name: Push to Github Container Registry
       run: docker push ${{ env.IMAGE_NAME }}
     

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ COPY requirements.txt .
 COPY requirements_test.txt .
 COPY .git .git
 COPY .gitmodules .
-COPY ocrd_tesserocr .
+COPY ocrd_tesserocr ocrd_tesserocr
 COPY repo/tesserocr repo/tesserocr
 COPY repo/tesseract repo/tesseract
 COPY Makefile .
@@ -66,7 +66,5 @@ RUN ln -s $XDG_CONFIG_HOME/ocrd-tesserocr-recognize $TESSDATA_PREFIX
 # finally, alias/symlink all ocrd-resources to /models for shorter mount commands
 RUN mv $XDG_CONFIG_HOME /models && ln -s /models $XDG_CONFIG_HOME
 
-
-# finally, alias/symlink all ocrd-resources to /models for shorter mount commands
 WORKDIR /data
 VOLUME /data


### PR DESCRIPTION
The current ocrd/tesserocr-image is broken. When I run `docker run --rm ocrd/tesserocr ocrd-tesserocr-segment-region --help` I get:
```
Traceback (most recent call last):
  File "/usr/local/bin/ocrd-tesserocr-recognize", line 5, in <module>
    from ocrd_tesserocr.cli import ocrd_tesserocr_recognize
ModuleNotFoundError: No module named 'ocrd_tesserocr'
```
I think when modifying the image lately the copy command was changed in the wrong way, which is fixed by this pr