### PR TITLE
docker: use version from git tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,67 +35,11 @@ jobs:
       - codecov/upload
     resource_class: large
 
-  build-docker:
-    docker:
-      - image: circleci/buildpack-deps:stretch
-    environment:
-      DOCKER_TAG: ocrd/tesserocr
-    steps:
-      - checkout
-      - run: git submodule sync && git submodule update --init
-      - setup_remote_docker: # https://circleci.com/docs/2.0/building-docker-images/
-          docker_layer_caching: true
-      - run: make docker DOCKER_TAG=$DOCKER_TAG
-      - run: docker run --rm $DOCKER_TAG ocrd-tesserocr-segment -h
-
-  deploy-docker:
-    docker:
-      - image: circleci/buildpack-deps:stretch
-    environment:
-      DOCKER_TAG: ocrd/tesserocr
-    steps:
-      - checkout
-      - run: git submodule sync && git submodule update --init
-      - setup_remote_docker: # https://circleci.com/docs/2.0/building-docker-images/
-          docker_layer_caching: true
-      - run: make docker DOCKER_TAG=$DOCKER_TAG
-      - run: docker run --rm $DOCKER_TAG ocrd-tesserocr-segment -h
-      - run:
-          name: Login to Docker Hub
-          command: echo "$DOCKERHUB_PASS" | docker login --username "$DOCKERHUB_USER" --password-stdin
-      - run: docker push $DOCKER_TAG
-
-  deploy-pypi:
-    docker:
-      - image: ocrd/tesserocr
-    steps:
-      - checkout
-      - run: pip install twine build
-      - run: python -m build .
-      - run: twine upload dist/*
-
-
 workflows:
   build:
     jobs:
       - test-python:
           matrix:
             parameters:
-              python-version: ['3.8', '3.9', '3.10', '3.11']
-      - build-docker
+              python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
-  deploy:
-    when:
-      condition:
-        equal: [ https://github.com/OCR-D/ocrd_tesserocr, << pipeline.project.git_url >>]
-    jobs:
-      - deploy-docker:
-          filters:
-            branches:
-              only: master
-      - deploy-pypi:
-          requires:
-            - deploy-docker
-          filters:
-            branches:
-              only: master

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -19,7 +19,9 @@ jobs:
         with:
           python-version: 3.9
       - name: Build package
-        run: make build
+        run: |
+          pip install build
+          python -m build
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -1,0 +1,26 @@
+name: PyPI CD
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  pypi-publish:
+    name: upload release to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for Trusted Publishing
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+      - name: Build package
+        run: make build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,12 +1,9 @@
 name: Docker Image CI
 
 on:
-  workflow_dispatch:
   push:
     branches: [ "master" ]
-
-env:
-  REPO_NAME: ${{ github.repository }}
+  workflow_dispatch: # run manually
 
 jobs:
 
@@ -18,24 +15,35 @@ jobs:
       contents: read
     
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        # we need tags for docker version tagging
+        fetch-tags: true
+        fetch-depth: 0
     - name: Checkout git submodules too
       run: git submodule sync && git submodule update --init
     - # Activate cache export feature to reduce build time of images
       name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - name: define image name from repo name
-      run: echo "IMAGE_NAME=ghcr.io/${REPO_NAME,,}" >> $GITHUB_ENV
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERIO_USERNAME }}
+        password: ${{ secrets.DOCKERIO_PASSWORD }}
+    - name: define unversioned fully qualified docker image names
+      run: echo "DOCKER_TAG='docker.io/ocrd/tesserocr ghcr.io/ocr-d/tesserocr'" >> $GITHUB_ENV
     - name: Build the Docker image
-      run: make docker DOCKER_TAG=${{ env.IMAGE_NAME }}
-    - name: Test the Docker image
-      run: docker run --rm ${{ env.IMAGE_NAME }} ocrd-tesserocr-segment -h
-    - name: Push to Github Container Registry
-      run: docker push ${{ env.IMAGE_NAME }}
+      # build both tags at the same time
+      run: make DOCKER_TAG="${{ env.DOCKER_TAG }}" docker
+    - name: Smoke Test the Docker image
+      run: make DOCKER_TAG="${{ env.DOCKER_TAG }}" docker-smoke-test
+    - name: Push to Dockerhub and Github Container Registry
+      run: make DOCKER_TAG="${{ env.DOCKER_TAG }}" docker-push
     

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -35,8 +35,8 @@ jobs:
     - name: Log in to Docker Hub
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKERIO_USERNAME }}
-        password: ${{ secrets.DOCKERIO_PASSWORD }}
+        username: ${{ secrets.DOCKERHUB_USER }}
+        password: ${{ secrets.DOCKERHUB_PASS }}
     - name: define unversioned fully qualified docker image names
       run: echo "DOCKER_TAG='docker.io/ocrd/tesserocr ghcr.io/ocr-d/tesserocr'" >> $GITHUB_ENV
     - name: Build the Docker image

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ export
 PYTEST_ARGS =
 
 # Docker container tag
-DOCKER_TAG = 'ocrd/tesserocr'
+DOCKER_TAG = ocrd/tesserocr
 DOCKER_BASE_IMAGE = docker.io/ocrd/core:v3.12.3
 
 help:
@@ -100,13 +100,20 @@ deps-test:
 	ocrd resmgr download ocrd-tesserocr-recognize deu.traineddata
 	ocrd resmgr download ocrd-tesserocr-recognize Fraktur.traineddata
 
+# Concatenate docker image names with either the git tag describing current commit or 'latest' and
+# merge list with "-t"
+empty :=
+space := $(empty) $(empty)
+GIT_TAG := $(strip $(shell git describe --tags | grep -x "v[0-9]\+\.[0-9]\+\.[0-9]\+"))
+DOCKER_TAGS = $(subst $(space),$(space)-t$(space),$(DOCKER_TAG:%=$(if $(GIT_TAG),%:$(GIT_TAG),%:latest)))
+
 # Build docker image
 docker: repo/tesseract repo/tesserocr
 	docker build \
 	--build-arg DOCKER_BASE_IMAGE=$(DOCKER_BASE_IMAGE) \
 	--build-arg VCS_REF=$$(git rev-parse --short HEAD) \
 	--build-arg BUILD_DATE=$$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
-	-t $(DOCKER_TAG) .
+	-t $(DOCKER_TAGS) .
 
 install-tesserocr: repo/tesserocr install-tesseract
 	$(PIP) install ./$<

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,8 @@ deps-test:
 empty :=
 space := $(empty) $(empty)
 GIT_TAG := $(strip $(shell git describe --tags | grep -x "v[0-9]\+\.[0-9]\+\.[0-9]\+"))
-DOCKER_TAGS = $(subst $(space),$(space)-t$(space),$(DOCKER_TAG:%=$(if $(GIT_TAG),%:$(GIT_TAG),%:latest)))
+DOCKER_TAGS = $(DOCKER_TAG:%=$(if $(GIT_TAG),%:$(GIT_TAG),%:latest))
+DOCKER_TAGS_T = $(subst $(space),$(space)-t$(space),$(DOCKER_TAGS))
 
 # Build docker image
 docker: repo/tesseract repo/tesserocr
@@ -113,7 +114,7 @@ docker: repo/tesseract repo/tesserocr
 	--build-arg DOCKER_BASE_IMAGE=$(DOCKER_BASE_IMAGE) \
 	--build-arg VCS_REF=$$(git rev-parse --short HEAD) \
 	--build-arg BUILD_DATE=$$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
-	-t $(DOCKER_TAGS) .
+	-t $(DOCKER_TAGS_T) .
 
 install-tesserocr: repo/tesserocr install-tesseract
 	$(PIP) install ./$<

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,15 @@ docker: repo/tesseract repo/tesserocr
 	--build-arg BUILD_DATE=$$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
 	-t $(DOCKER_TAGS_T) .
 
+# Push docker images
+docker-push:
+	for img in $(DOCKER_TAGS);do \
+		$(DOCKER) push $$img & \
+	done; wait
+
+docker-smoke-test:
+	$(DOCKER) run --rm $(firstword DOCKER_TAGS) ocrd-page2alto-transform -h
+
 install-tesserocr: repo/tesserocr install-tesseract
 	$(PIP) install ./$<
 

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ docker-push:
 	done; wait
 
 docker-smoke-test:
-	$(DOCKER) run --rm $(firstword DOCKER_TAGS) ocrd-page2alto-transform -h
+	$(DOCKER) run --rm $(firstword DOCKER_TAGS) ocrd-tesserocr-segment -h
 
 install-tesserocr: repo/tesserocr install-tesseract
 	$(PIP) install ./$<


### PR DESCRIPTION
* Use versioned releases whenever possible (i.e. after release with version as git tag)
* Use GH Actions for all docker image building and pushing - ghcr.io with GHA and docker.io with CircleCI offers no benefits AFAICT
* Do the PyPI releases in a separate GHA workflow with OpenID Connect instead of token-based auth